### PR TITLE
지역 Feign Client 컨트롤러 테스트 기능 및 테스트 코드 구현

### DIFF
--- a/area/src/main/java/com/linkeleven/msa/area/application/dto/external/AdministrativeRegionDto.java
+++ b/area/src/main/java/com/linkeleven/msa/area/application/dto/external/AdministrativeRegionDto.java
@@ -10,5 +10,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class AdministrativeRegionDto {
-	private String regionName;
+	private Long areaId;
 }

--- a/area/src/main/java/com/linkeleven/msa/area/application/dto/external/AdministrativeRegionDto.java
+++ b/area/src/main/java/com/linkeleven/msa/area/application/dto/external/AdministrativeRegionDto.java
@@ -1,0 +1,14 @@
+package com.linkeleven.msa.area.application.dto.external;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdministrativeRegionDto {
+	private String regionName;
+}

--- a/area/src/main/java/com/linkeleven/msa/area/libs/dto/ExceptionResponseDto.java
+++ b/area/src/main/java/com/linkeleven/msa/area/libs/dto/ExceptionResponseDto.java
@@ -1,0 +1,17 @@
+package com.linkeleven.msa.area.libs.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ExceptionResponseDto<T> {
+
+	private final Integer status;
+	private final String message;
+	private final T data;
+
+	public static <T> ExceptionResponseDto<T> of(Integer status, String message, T data) {
+		return new ExceptionResponseDto<>(status, message, data);
+	}
+}

--- a/area/src/main/java/com/linkeleven/msa/area/libs/dto/SuccessResponseDto.java
+++ b/area/src/main/java/com/linkeleven/msa/area/libs/dto/SuccessResponseDto.java
@@ -1,0 +1,41 @@
+package com.linkeleven.msa.area.libs.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class SuccessResponseDto<T> {
+	private final String message; // 응답 메시지
+	private final T data; // 선택적으로 포함할 데이터
+
+	/**
+	 * 성공 응답 생성 - 데이터 없이 메시지만 반환
+	 */
+	public static SuccessResponseDto<Void> success(String message) {
+		return SuccessResponseDto.<Void>builder()
+			.message(message)
+			.build();
+	}
+
+	/**
+	 * 성공 응답 생성 - 데이터 포함
+	 */
+	public static <T> SuccessResponseDto<T> success(String message, T data) {
+		return SuccessResponseDto.<T>builder()
+			.message(message)
+			.data(data)
+			.build();
+	}
+
+	/**
+	 * 에러 응답 생성 - 메시지만 반환
+	 */
+	public static SuccessResponseDto<Void> error(String errorMessage) {
+		return SuccessResponseDto.<Void>builder()
+			.message(errorMessage)
+			.build();
+	}
+}

--- a/area/src/main/java/com/linkeleven/msa/area/libs/exception/CustomException.java
+++ b/area/src/main/java/com/linkeleven/msa/area/libs/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.linkeleven.msa.area.libs.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+	private final String message;
+
+	public CustomException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+		this.message = errorCode.getMessage();
+	}
+}

--- a/area/src/main/java/com/linkeleven/msa/area/libs/exception/ErrorCode.java
+++ b/area/src/main/java/com/linkeleven/msa/area/libs/exception/ErrorCode.java
@@ -1,0 +1,37 @@
+package com.linkeleven.msa.area.libs.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+	/*  400 BAD_REQUEST : 잘못된 요청  */
+	ILLEGAL_ARGUMENT_ERROR(400, "잘못된 파라미터 전달"),
+
+
+	/*  401 UNAUTHORIZED : 인증 안됨  */
+	UNAUTHORIZED(401, "인증되지 않았습니다."),
+
+	/*  403 FORBIDDEN : 권한 없음  */
+	FORBIDDEN(403, "권한이 없습니다."),
+
+
+	/*  404 NOT_FOUND : Resource 권한 없음, Resource 를 찾을 수 없음  */
+	ACCESS_DENIED(404, "접근 권한이 없습니다."),
+
+	/*  408 REQUEST_TIMEOUT : 요청에 대한 응답 시간 초과  */
+	TIMEOUT_ERROR(408, "응답시간을 초과하였습니다."),
+
+	/*  409 CONFLICT : Resource 중복  */
+
+	/*  500 INTERNAL_SERVER_ERROR : 서버 에러  */
+	INTERNAL_SERVER_ERROR(500, "내부 서버 에러입니다.");
+
+
+	/*  502 BAD_GATEWAY  연결 실패   */
+
+	private final Integer httpStatus;
+	private final String message;
+}

--- a/area/src/main/java/com/linkeleven/msa/area/libs/exception/GlobalExceptionHandler.java
+++ b/area/src/main/java/com/linkeleven/msa/area/libs/exception/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package com.linkeleven.msa.area.libs.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.linkeleven.msa.area.libs.dto.ExceptionResponseDto;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	/**
+	 * [Exception] CustomException 반환 ErrorCode에 작성된 예외를 반환하는 경우 사용
+	 *
+	 * @param e CustomException
+	 * @return ResponseEntity<ExceptionResponse>
+	 */
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ExceptionResponseDto<Void>> customExceptionHandler(CustomException e) {
+		log.error("CustomException: " + e);
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(
+			ExceptionResponseDto.of(
+				e.getErrorCode().getHttpStatus(),
+				e.getErrorCode().getMessage(),
+				null
+			)
+		);
+	}
+
+	/**
+	 * [Exception] RuntimeException 반환
+	 *
+	 * @param e RuntimeException
+	 * @return ResponseEntity<ExceptionResponse>
+	 */
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ExceptionResponseDto<Void>> runtimeExceptionHandler(RuntimeException e) {
+		log.error("RuntimeException: ", e);
+		return ResponseEntity.internalServerError().body(
+			ExceptionResponseDto.of(
+				ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus(),
+				ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
+				null)
+		);
+	}
+}

--- a/area/src/main/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalController.java
+++ b/area/src/main/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalController.java
@@ -1,0 +1,52 @@
+package com.linkeleven.msa.area.presentation.controller.external;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.linkeleven.msa.area.application.dto.external.AdministrativeRegionDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/external")
+public class AreaExternalController {
+
+
+	// 내가 해당하는 지역의 행정구역
+	@GetMapping("/location")
+	public AdministrativeRegionDto findAdministrativeRegion(
+		@RequestParam double latitude,
+		@RequestParam double longitude
+	){
+
+		return AdministrativeRegionDto.builder()
+			.regionName("서울특별시")
+			.build();
+	}
+
+	// 해당 주소 입력의 지역 행정구역
+	@GetMapping("/location/{address}")
+	public AdministrativeRegionDto findAddressRegion(
+		@PathVariable String address
+	){
+		return AdministrativeRegionDto.builder()
+			.regionName("서울특별시")
+			.build();
+	}
+
+	// 해당 키워드 입력의 지역 행정구역
+	@GetMapping("/location/keyword")
+	public AdministrativeRegionDto findKeywordByRegion(
+		@RequestParam String keyword
+	){
+		return AdministrativeRegionDto.builder()
+			.regionName("서울특별시")
+			.build();
+	}
+
+
+}

--- a/area/src/main/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalController.java
+++ b/area/src/main/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalController.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/external")
+@RequestMapping("/external/area")
 public class AreaExternalController {
 
 

--- a/area/src/main/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalController.java
+++ b/area/src/main/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalController.java
@@ -11,39 +11,39 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/external/area")
+@RequestMapping("/external/areas")
 public class AreaExternalController {
 
 
 	// 내가 해당하는 지역의 행정구역
-	@GetMapping("/location/coordinate")
+	@GetMapping("/locations/coordinates")
 	public AdministrativeRegionDto findAdministrativeRegion(
 		@RequestParam double latitude,
 		@RequestParam double longitude
 	){
 
 		return AdministrativeRegionDto.builder()
-			.regionName("서울특별시")
+			.areaId(556028620837202474L)
 			.build();
 	}
 
 	// 해당 주소 입력의 지역 행정구역
-	@GetMapping("/location/address")
+	@GetMapping("/locations/address")
 	public AdministrativeRegionDto findAddressRegion(
 		@RequestParam String address
 	){
 		return AdministrativeRegionDto.builder()
-			.regionName("서울특별시")
+			.areaId(556028620837202474L)
 			.build();
 	}
 
 	// 해당 키워드 입력의 지역 행정구역
-	@GetMapping("/location/keyword")
+	@GetMapping("/locations/keywords")
 	public AdministrativeRegionDto findKeywordByRegion(
 		@RequestParam String keyword
 	){
 		return AdministrativeRegionDto.builder()
-			.regionName("서울특별시")
+			.areaId(556028620837202474L)
 			.build();
 	}
 

--- a/area/src/main/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalController.java
+++ b/area/src/main/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalController.java
@@ -1,7 +1,6 @@
 package com.linkeleven.msa.area.presentation.controller.external;
 
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +16,7 @@ public class AreaExternalController {
 
 
 	// 내가 해당하는 지역의 행정구역
-	@GetMapping("/location")
+	@GetMapping("/location/coordinate")
 	public AdministrativeRegionDto findAdministrativeRegion(
 		@RequestParam double latitude,
 		@RequestParam double longitude
@@ -29,9 +28,9 @@ public class AreaExternalController {
 	}
 
 	// 해당 주소 입력의 지역 행정구역
-	@GetMapping("/location/{address}")
+	@GetMapping("/location/address")
 	public AdministrativeRegionDto findAddressRegion(
-		@PathVariable String address
+		@RequestParam String address
 	){
 		return AdministrativeRegionDto.builder()
 			.regionName("서울특별시")

--- a/area/src/test/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalControllerTest.java
+++ b/area/src/test/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalControllerTest.java
@@ -1,0 +1,42 @@
+package com.linkeleven.msa.area.presentation.controller.external;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AreaExternalControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	void testFindAdministrativeRegion() throws Exception {
+		mockMvc.perform(get("/external/location")
+				.param("latitude", "37.5665")
+				.param("longitude", "126.9780"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.regionName").value("서울특별시"));
+	}
+
+	@Test
+	void testFindAddressRegion() throws Exception {
+		mockMvc.perform(get("/external/location/{address}", "서울특별시 강남구"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.regionName").value("서울특별시"));
+	}
+
+	@Test
+	void testFindKeywordByRegion() throws Exception {
+		mockMvc.perform(get("/external/location/keyword")
+				.param("keyword", "강남"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.regionName").value("서울특별시"));
+	}
+}

--- a/area/src/test/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalControllerTest.java
+++ b/area/src/test/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalControllerTest.java
@@ -18,7 +18,7 @@ class AreaExternalControllerTest {
 
 	@Test
 	void testFindAdministrativeRegion() throws Exception {
-		mockMvc.perform(get("/external/location")
+		mockMvc.perform(get("/external/area/location/coordinate")
 				.param("latitude", "37.5665")
 				.param("longitude", "126.9780"))
 			.andExpect(status().isOk())
@@ -27,14 +27,15 @@ class AreaExternalControllerTest {
 
 	@Test
 	void testFindAddressRegion() throws Exception {
-		mockMvc.perform(get("/external/location/{address}", "서울특별시 강남구"))
+		mockMvc.perform(get("/external/area/location/address")
+				.param("address", "서울특별시 강남구 강남대로 390"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.regionName").value("서울특별시"));
 	}
 
 	@Test
 	void testFindKeywordByRegion() throws Exception {
-		mockMvc.perform(get("/external/location/keyword")
+		mockMvc.perform(get("/external/area/location/keyword")
 				.param("keyword", "강남"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.regionName").value("서울특별시"));

--- a/area/src/test/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalControllerTest.java
+++ b/area/src/test/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalControllerTest.java
@@ -18,26 +18,26 @@ class AreaExternalControllerTest {
 
 	@Test
 	void testFindAdministrativeRegion() throws Exception {
-		mockMvc.perform(get("/external/area/location/coordinate")
+		mockMvc.perform(get("/external/areas/locations/coordinates")
 				.param("latitude", "37.5665")
 				.param("longitude", "126.9780"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.regionName").value("서울특별시"));
+			.andExpect(jsonPath("$.regionName").value(556028620837202474L));
 	}
 
 	@Test
 	void testFindAddressRegion() throws Exception {
-		mockMvc.perform(get("/external/area/location/address")
+		mockMvc.perform(get("/external/areas/locations/address")
 				.param("address", "서울특별시 강남구 강남대로 390"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.regionName").value("서울특별시"));
+			.andExpect(jsonPath("$.regionName").value(556028620837202474L));
 	}
 
 	@Test
 	void testFindKeywordByRegion() throws Exception {
-		mockMvc.perform(get("/external/area/location/keyword")
+		mockMvc.perform(get("/external/areas/locations/keyword")
 				.param("keyword", "강남"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.regionName").value("서울특별시"));
+			.andExpect(jsonPath("$.regionName").value(556028620837202474L));
 	}
 }

--- a/area/src/test/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalControllerTest.java
+++ b/area/src/test/java/com/linkeleven/msa/area/presentation/controller/external/AreaExternalControllerTest.java
@@ -22,7 +22,7 @@ class AreaExternalControllerTest {
 				.param("latitude", "37.5665")
 				.param("longitude", "126.9780"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.regionName").value(556028620837202474L));
+			.andExpect(jsonPath("$.areaId").value(556028620837202474L));
 	}
 
 	@Test
@@ -30,14 +30,14 @@ class AreaExternalControllerTest {
 		mockMvc.perform(get("/external/areas/locations/address")
 				.param("address", "서울특별시 강남구 강남대로 390"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.regionName").value(556028620837202474L));
+			.andExpect(jsonPath("$.areaId").value(556028620837202474L));
 	}
 
 	@Test
 	void testFindKeywordByRegion() throws Exception {
-		mockMvc.perform(get("/external/areas/locations/keyword")
+		mockMvc.perform(get("/external/areas/locations/keywords")
 				.param("keyword", "강남"))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.regionName").value(556028620837202474L));
+			.andExpect(jsonPath("$.areaId").value(556028620837202474L));
 	}
 }


### PR DESCRIPTION
#️⃣ 연관된 이슈

- #2 


📝 Description

지역 서비스에서의 Feign Client 기능을 컨트롤러에서 간략하게 구현 했습니다.
1. 주소나 키워드의 입력이 없을때 사용자의 위경도를 통한 지역의 행적구역 응답 기능
2. 주소 입력을 통한 행정구역 응답 기능
3. 키워드 입력을 통한 행정구역 응답 기능

Feign Client 엔드포인트라 Swagger 문서화는 진행하지 않았습니다.
💬 To Reivewers


테스트 성공(이미지 OR 코드 첨부)
- 테스트 성공 이미지나 테스트 코드 성공 사진 부탁드립니다.
![image](https://github.com/user-attachments/assets/5343a878-a572-47e2-86a3-1aa760599655)


리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. (생략 가능)
- 없습니다
