### PR TITLE
댓글 엔티티, 값객체 애그리거트 생성

### DIFF
--- a/interaction/src/main/java/com/linkeleven/msa/interaction/InteractionApplication.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/InteractionApplication.java
@@ -3,9 +3,11 @@ package com.linkeleven.msa.interaction;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableJpaAuditing
 public class InteractionApplication {
 
 	public static void main(String[] args) {

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/entity/BaseTime.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/entity/BaseTime.java
@@ -1,0 +1,46 @@
+package com.linkeleven.msa.interaction.domain.model.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTime {
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Setter
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Setter
+	@CreatedBy
+	@Column(name = "created_by", updatable = false)
+	private Long createdBy;
+
+	@Setter
+	@LastModifiedBy
+	@Column(name = "updated_by")
+	private Long updatedBy;
+
+	@Setter
+	@Column(name = "deleted_by")
+	private Long deletedBy;
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/entity/Comment.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/entity/Comment.java
@@ -1,0 +1,111 @@
+package com.linkeleven.msa.interaction.domain.model.entity;
+
+import java.time.LocalDateTime;
+
+import com.linkeleven.msa.interaction.domain.model.vo.ContentDetails;
+import com.linkeleven.msa.interaction.libs.exception.CustomException;
+import com.linkeleven.msa.interaction.libs.exception.ErrorCode;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "p_comment")
+public class Comment extends BaseTime{
+
+	@Id
+	@Tsid
+	private Long id;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "content", column = @Column(name = "content", nullable = false)),
+		@AttributeOverride(name = "userId", column = @Column(name = "userId", nullable = false, updatable = false))
+	})
+	private ContentDetails contentDetails;
+
+	@Column(nullable = false, updatable = false)
+	private Long feedId;
+
+	// @Column
+	// private boolean isReported;
+	//
+	// @Column
+	// private String reportReason;
+
+	@Builder
+	private Comment(ContentDetails contentDetails, Long feedId) {
+		this.contentDetails = contentDetails;
+		this.feedId = feedId;
+		// this.isReported = false;
+		// this.reportReason = null;
+	}
+
+	public static Comment of(ContentDetails contentDetails, Long feedId) {
+		return Comment.builder()
+			.contentDetails(contentDetails)
+			.feedId(feedId)
+			.build();
+	}
+
+	public void updateComment(String newContent) {
+		if (isDeleted()) {
+			throw new CustomException(ErrorCode.COMMENT_ALREADY_DELETED);
+		}
+		/**
+		 *   0. 위 검증로직 서비스로 이동하기
+		 *   1. 헤더로 받은 userId 검증
+		 *   2. 파라미터로 받은 feedId가 같은지 검증
+		 */
+		this.contentDetails = ContentDetails.of(newContent, this.contentDetails.getUserId());
+	}
+
+	public void deleteComment() {
+		if (isDeleted()) {
+			this.setDeletedAt(LocalDateTime.now());
+			this.contentDetails = ContentDetails.of("삭제된 댓글입니다.", this.contentDetails.getUserId());
+		} else {
+			throw new CustomException(ErrorCode.COMMENT_ALREADY_DELETED);
+		}
+	}
+
+
+	/**
+	 *  신고처리 된 경우엔 isReported를 확인해서 "블라인드된 댓글입니다." 를 반환해주면 됨
+	 */
+
+	// public void reportComment(String reason) {
+	// 	if (this.isReported) {
+	// 		throw new CustomException(ErrorCode.COMMENT_ALREADY_REPORTED);
+	// 	}
+	// 	this.isReported = true;
+	// 	this.reportReason = reason;
+	// }
+	//
+	// public void rollbackReportComment() {
+	// 	if (!this.isReported) {
+	// 		throw new CustomException(ErrorCode.COMMENT_IS_NOT_REPORTED);
+	// 	}
+	// 	this.isReported = false;
+	// 	this.reportReason = null;
+	// }
+
+
+	private boolean isDeleted() {
+		return this.getDeletedAt() == null;
+	}
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/entity/Reply.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/entity/Reply.java
@@ -1,0 +1,105 @@
+package com.linkeleven.msa.interaction.domain.model.entity;
+
+import java.time.LocalDateTime;
+
+import com.linkeleven.msa.interaction.domain.model.vo.ContentDetails;
+import com.linkeleven.msa.interaction.libs.exception.CustomException;
+import com.linkeleven.msa.interaction.libs.exception.ErrorCode;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "p_reply")
+public class Reply extends BaseTime{
+
+	@Id
+	@Tsid
+	private Long id;
+
+	@Embedded
+	@AttributeOverrides({
+		@AttributeOverride(name = "content", column = @Column(name = "content", nullable = false)),
+		@AttributeOverride(name = "userId", column = @Column(name = "userId", nullable = false, updatable = false))
+	})
+	private ContentDetails contentDetails;
+
+	@Column(name = "comment_id", nullable = false, updatable = false)
+	private Long commentId;
+
+	// @Column
+	// private boolean isReported;
+	//
+	// @Column
+	// private String reportReason;
+
+	@Builder
+	private Reply(ContentDetails contentDetails, Long commentId) {
+		this.contentDetails = contentDetails;
+		this.commentId = commentId;
+		// this.isReported = false;
+		// this.reportReason = null;
+	}
+
+	public static Reply of(ContentDetails contentDetails, Long commentId) {
+		return Reply.builder()
+			.contentDetails(contentDetails)
+			.commentId(commentId)
+			.build();
+	} // TODO: 대댓글 생성시 댓글 id exists 체크,  삭제유무 체크
+
+	public void updateReply(String newContent) {
+		if (isDeleted()) {
+			throw new CustomException(ErrorCode.REPLY_ALREADY_DELETED);
+		}
+		/**
+		 *  0. 위 검증로직 서비스로 이동
+		 *  1. 댓글  id  검사
+		 *  2. 헤더로 받은 userId 검증
+		 */
+		this.contentDetails = ContentDetails.of(newContent, this.contentDetails.getUserId());
+	}
+
+	public void deleteReply() {
+		if (isDeleted()) {
+			this.setDeletedAt(LocalDateTime.now());
+		} else {
+			throw new CustomException(ErrorCode.REPLY_ALREADY_DELETED);
+		}
+	}
+
+
+	// public void reportReply(String reason) {
+	// 	if (this.isReported) {
+	// 		throw new CustomException(ErrorCode.REPLY_ALREADY_REPORTED);
+	// 	}
+	// 	this.isReported = true;
+	// 	this.reportReason = reason;
+	// }
+	//
+	// public void rollbackReportReply() {
+	// 	if (!this.isReported) {
+	// 		throw new CustomException(ErrorCode.REPLY_IS_NOT_REPORTED);
+	// 	}
+	// 	this.isReported = false;
+	// 	this.reportReason = null;
+	// }
+
+	private boolean isDeleted() {
+		return this.getDeletedAt() == null;
+	}
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/vo/ContentDetails.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/vo/ContentDetails.java
@@ -1,0 +1,39 @@
+package com.linkeleven.msa.interaction.domain.model.vo;
+
+import com.linkeleven.msa.interaction.libs.exception.CustomException;
+import com.linkeleven.msa.interaction.libs.exception.ErrorCode;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContentDetails {
+
+	private String content;
+
+	private Long userId;
+
+	public static ContentDetails of(String content, Long userId) {
+		validate(content, userId);
+		return new ContentDetails(content, userId);
+	}
+
+	private static void validate(String content, Long userId) {
+		if (content == null || content.isBlank()) {
+			throw new CustomException(ErrorCode.CONTENT_CANNOT_BE_NULL_OR_EMPTY);
+		}
+		if (content.length() > 100) {
+			throw new CustomException(ErrorCode.CONTENT_TOO_LONG);
+		}
+		if (userId == null || userId <= 0) {
+			throw new CustomException(ErrorCode.INVALID_USERID);
+		}
+	}
+
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/libs/dto/ExceptionResponseDto.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/libs/dto/ExceptionResponseDto.java
@@ -1,0 +1,17 @@
+package com.linkeleven.msa.interaction.libs.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ExceptionResponseDto<T> {
+
+	private final Integer status;
+	private final String message;
+	private final T data;
+
+	public static <T> ExceptionResponseDto<T> of(Integer status, String message, T data) {
+		return new ExceptionResponseDto<>(status, message, data);
+	}
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/libs/dto/SuccessResponseDto.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/libs/dto/SuccessResponseDto.java
@@ -1,0 +1,41 @@
+package com.linkeleven.msa.interaction.libs.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class SuccessResponseDto<T> {
+	private final String message; // 응답 메시지
+	private final T data; // 선택적으로 포함할 데이터
+
+	/**
+	 * 성공 응답 생성 - 데이터 없이 메시지만 반환
+	 */
+	public static SuccessResponseDto<Void> success(String message) {
+		return SuccessResponseDto.<Void>builder()
+			.message(message)
+			.build();
+	}
+
+	/**
+	 * 성공 응답 생성 - 데이터 포함
+	 */
+	public static <T> SuccessResponseDto<T> success(String message, T data) {
+		return SuccessResponseDto.<T>builder()
+			.message(message)
+			.data(data)
+			.build();
+	}
+
+	/**
+	 * 에러 응답 생성 - 메시지만 반환
+	 */
+	public static SuccessResponseDto<Void> error(String errorMessage) {
+		return SuccessResponseDto.<Void>builder()
+			.message(errorMessage)
+			.build();
+	}
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/libs/exception/CustomException.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/libs/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.linkeleven.msa.interaction.libs.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+	private final String message;
+
+	public CustomException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+		this.message = errorCode.getMessage();
+	}
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/libs/exception/ErrorCode.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/libs/exception/ErrorCode.java
@@ -11,8 +11,14 @@ public enum ErrorCode {
 	/*  400 BAD_REQUEST : 잘못된 요청  */
 	EXPIRED_TOKEN(400, "만료된 토큰입니다."),
 	CONTENT_CANNOT_BE_NULL_OR_EMPTY(400, "댓글 내용은 null 또는 빈 값일 수 없습니다."),
-	CONTENT_TOO_LONG(400, "댓글은 500자 이내로 작성해야 합니다."),
+	CONTENT_TOO_LONG(400, "100자 이내로 작성해야 합니다."),
 	INVALID_USERID(400, "유효하지않은 유저ID입니다"),
+	COMMENT_ALREADY_DELETED(400, "이미 삭제된 댓글입니다"),
+	COMMENT_ALREADY_REPORTED(400, "이미 신고 처리된 댓글입니다"),
+	COMMENT_IS_NOT_REPORTED(400, "신고된 댓글이 아닙니다"),
+	REPLY_ALREADY_DELETED(400, "이미 삭제된 대댓글입니다"),
+	REPLY_ALREADY_REPORTED(400, "이미 신고 처리된 대댓글입니다"),
+	REPLY_IS_NOT_REPORTED(400, "신고된 대댓글이 아닙니다"),
 
 	/*  401 UNAUTHORIZED : 인증 안됨  */
 	UNAUTHORIZED(401, "인증되지 않았습니다."),
@@ -23,6 +29,7 @@ public enum ErrorCode {
 	/*  404 NOT_FOUND : Resource 권한 없음, Resource 를 찾을 수 없음  */
 	ACCESS_DENIED(404, "접근 권한이 없습니다."),
 	USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),
+	COMMENT_NOT_FOUND(404, "댓글을 찾을 수 없습니다."),
 
 	/*  408 REQUEST_TIMEOUT : 요청에 대한 응답 시간 초과  */
 	TIMEOUT_ERROR(408, "응답시간을 초과하였습니다."),

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/libs/exception/ErrorCode.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/libs/exception/ErrorCode.java
@@ -1,0 +1,41 @@
+package com.linkeleven.msa.interaction.libs.exception;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+	/*  400 BAD_REQUEST : 잘못된 요청  */
+	EXPIRED_TOKEN(400, "만료된 토큰입니다."),
+	CONTENT_CANNOT_BE_NULL_OR_EMPTY(400, "댓글 내용은 null 또는 빈 값일 수 없습니다."),
+	CONTENT_TOO_LONG(400, "댓글은 500자 이내로 작성해야 합니다."),
+	INVALID_USERID(400, "유효하지않은 유저ID입니다"),
+
+	/*  401 UNAUTHORIZED : 인증 안됨  */
+	UNAUTHORIZED(401, "인증되지 않았습니다."),
+
+	/*  403 FORBIDDEN : 권한 없음  */
+	FORBIDDEN(403, "권한이 없습니다."),
+
+	/*  404 NOT_FOUND : Resource 권한 없음, Resource 를 찾을 수 없음  */
+	ACCESS_DENIED(404, "접근 권한이 없습니다."),
+	USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),
+
+	/*  408 REQUEST_TIMEOUT : 요청에 대한 응답 시간 초과  */
+	TIMEOUT_ERROR(408, "응답시간을 초과하였습니다."),
+
+	/*  409 CONFLICT : Resource 중복  */
+
+	/*  500 INTERNAL_SERVER_ERROR : 서버 에러  */
+	INTERNAL_SERVER_ERROR(500, "내부 서버 에러입니다."),
+	INTERRUPTED_ERROR(500, " Interrupted 에러 발생."),
+
+	/*  502 BAD_GATEWAY  연결 실패   */
+	;
+
+	private final Integer httpStatus;
+	private final String message;
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/libs/exception/GlobalExceptionHandler.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/libs/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.linkeleven.msa.interaction.libs.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.linkeleven.msa.interaction.libs.dto.ExceptionResponseDto;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+	/**
+	 * [Exception] CustomException 반환 ErrorCode에 작성된 예외를 반환하는 경우 사용
+	 *
+	 * @param e CustomException
+	 * @return ResponseEntity<ExceptionResponse>
+	 */
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ExceptionResponseDto<Void>> customExceptionHandler(CustomException e) {
+		log.error("CustomException: " + e);
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(
+			ExceptionResponseDto.of(
+				e.getErrorCode().getHttpStatus(),
+				e.getErrorCode().getMessage(),
+				null
+			)
+		);
+	}
+
+	/**
+	 * [Exception] RuntimeException 반환
+	 *
+	 * @param e RuntimeException
+	 * @return ResponseEntity<ExceptionResponse>
+	 */
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ExceptionResponseDto<Void>> runtimeExceptionHandler(RuntimeException e) {
+		log.error("RuntimeException: ", e);
+		return ResponseEntity.internalServerError().body(
+			ExceptionResponseDto.of(
+				ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus(),
+				ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
+				null)
+		);
+	}
+}

--- a/notification/src/main/java/com/linkeleven/msa/notification/libs/dto/ExceptionResponseDto.java
+++ b/notification/src/main/java/com/linkeleven/msa/notification/libs/dto/ExceptionResponseDto.java
@@ -1,0 +1,17 @@
+package com.linkeleven.msa.notification.libs.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ExceptionResponseDto<T> {
+
+	private final Integer status;
+	private final String message;
+	private final T data;
+
+	public static <T> ExceptionResponseDto<T> of(Integer status, String message, T data) {
+		return new ExceptionResponseDto<>(status, message, data);
+	}
+}

--- a/notification/src/main/java/com/linkeleven/msa/notification/libs/dto/SuccessResponseDto.java
+++ b/notification/src/main/java/com/linkeleven/msa/notification/libs/dto/SuccessResponseDto.java
@@ -1,0 +1,41 @@
+package com.linkeleven.msa.notification.libs.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class SuccessResponseDto<T> {
+	private final String message; // 응답 메시지
+	private final T data; // 선택적으로 포함할 데이터
+
+	/**
+	 * 성공 응답 생성 - 데이터 없이 메시지만 반환
+	 */
+	public static SuccessResponseDto<Void> success(String message) {
+		return SuccessResponseDto.<Void>builder()
+			.message(message)
+			.build();
+	}
+
+	/**
+	 * 성공 응답 생성 - 데이터 포함
+	 */
+	public static <T> SuccessResponseDto<T> success(String message, T data) {
+		return SuccessResponseDto.<T>builder()
+			.message(message)
+			.data(data)
+			.build();
+	}
+
+	/**
+	 * 에러 응답 생성 - 메시지만 반환
+	 */
+	public static SuccessResponseDto<Void> error(String errorMessage) {
+		return SuccessResponseDto.<Void>builder()
+			.message(errorMessage)
+			.build();
+	}
+}

--- a/notification/src/main/java/com/linkeleven/msa/notification/libs/exception/CustomException.java
+++ b/notification/src/main/java/com/linkeleven/msa/notification/libs/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.linkeleven.msa.notification.libs.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+	private final String message;
+
+	public CustomException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+		this.message = errorCode.getMessage();
+	}
+}

--- a/notification/src/main/java/com/linkeleven/msa/notification/libs/exception/ErrorCode.java
+++ b/notification/src/main/java/com/linkeleven/msa/notification/libs/exception/ErrorCode.java
@@ -1,0 +1,38 @@
+package com.linkeleven.msa.notification.libs.exception;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+	/*  400 BAD_REQUEST : 잘못된 요청  */
+	EXPIRED_TOKEN(400, "만료된 토큰입니다."),
+
+	/*  401 UNAUTHORIZED : 인증 안됨  */
+	UNAUTHORIZED(401, "인증되지 않았습니다."),
+
+	/*  403 FORBIDDEN : 권한 없음  */
+	FORBIDDEN(403, "권한이 없습니다."),
+
+	/*  404 NOT_FOUND : Resource 권한 없음, Resource 를 찾을 수 없음  */
+	ACCESS_DENIED(404, "접근 권한이 없습니다."),
+	USER_NOT_FOUND(404, "유저를 찾을 수 없습니다."),
+
+	/*  408 REQUEST_TIMEOUT : 요청에 대한 응답 시간 초과  */
+	TIMEOUT_ERROR(408, "응답시간을 초과하였습니다."),
+
+	/*  409 CONFLICT : Resource 중복  */
+
+	/*  500 INTERNAL_SERVER_ERROR : 서버 에러  */
+	INTERNAL_SERVER_ERROR(500, "내부 서버 에러입니다."),
+	INTERRUPTED_ERROR(500, " Interrupted 에러 발생."),
+
+	/*  502 BAD_GATEWAY  연결 실패   */
+	;
+
+	private final Integer httpStatus;
+	private final String message;
+}

--- a/notification/src/main/java/com/linkeleven/msa/notification/libs/exception/GlobalExceptionHandler.java
+++ b/notification/src/main/java/com/linkeleven/msa/notification/libs/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.linkeleven.msa.notification.libs.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.linkeleven.msa.interaction.libs.dto.ExceptionResponseDto;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+
+	/**
+	 * [Exception] CustomException 반환 ErrorCode에 작성된 예외를 반환하는 경우 사용
+	 *
+	 * @param e CustomException
+	 * @return ResponseEntity<ExceptionResponse>
+	 */
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ExceptionResponseDto<Void>> customExceptionHandler(CustomException e) {
+		log.error("CustomException: " + e);
+		return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(
+			ExceptionResponseDto.of(
+				e.getErrorCode().getHttpStatus(),
+				e.getErrorCode().getMessage(),
+				null
+			)
+		);
+	}
+
+	/**
+	 * [Exception] RuntimeException 반환
+	 *
+	 * @param e RuntimeException
+	 * @return ResponseEntity<ExceptionResponse>
+	 */
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ExceptionResponseDto<Void>> runtimeExceptionHandler(RuntimeException e) {
+		log.error("RuntimeException: ", e);
+		return ResponseEntity.internalServerError().body(
+			ExceptionResponseDto.of(
+				ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus(),
+				ErrorCode.INTERNAL_SERVER_ERROR.getMessage(),
+				null)
+		);
+	}
+}


### PR DESCRIPTION
#️⃣ 연관된 이슈

#9 


📝 Description

댓글 엔티티, 값객체, 애그리거트 
대댓글 엔티티, 값객체, 애그리거트

좋아요, 신고 기능 확장에 용이하도록 코드를 작성하였습니다.

<br>

확장성을 고려하여 (좋아요 및 다른 게시판이 생기는 경우)
댓글과 대댓글을 분리하였으며,  

댓글이 삭제되거나 신고되어도 대댓글은 남아있어야한다고 생각하여
둘 사이를 약결합으로 묶고
각각을 루트애그리거트로 만들었습니다.


<br>

💬 To Reivewers

검증로직과 주석은 서비스 코드 구현 시에 제거할 생각입니다.

틀린 부분 잘 지적부탁드려요~