### PR TITLE
댓글, 대댓글 전체 조회 구현 #8  #28

### DIFF
--- a/interaction/build.gradle
+++ b/interaction/build.gradle
@@ -54,10 +54,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// QueryDsl
-//	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
-//	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
-//	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
-//	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 }
 
 dependencyManagement {
@@ -65,6 +65,7 @@ dependencyManagement {
 		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
 	}
 }
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/interaction/build.gradle
+++ b/interaction/build.gradle
@@ -65,6 +65,10 @@ dependencyManagement {
 		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
 	}
 }
+//
+//tasks.withType(Test) {
+//	enabled = false
+//}
 
 
 tasks.named('test') {

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/CommentCreateResponseDto.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/CommentCreateResponseDto.java
@@ -13,12 +13,14 @@ public class CommentCreateResponseDto {
 
 	private Long commentId;
 	private Long userId;
+	private String username;
 	private String content;
 
-	public static CommentCreateResponseDto of(Long commentId, Long userId, String content) {
+	public static CommentCreateResponseDto of(Long commentId, Long userId, String username, String content) {
 		return CommentCreateResponseDto.builder()
 			.commentId(commentId)
 			.userId(userId)
+			.username(username)
 			.content(content)
 			.build();
 	}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/CommentQueryResponseDto.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/CommentQueryResponseDto.java
@@ -1,0 +1,24 @@
+package com.linkeleven.msa.interaction.application.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommentQueryResponseDto {
+
+	private Long commentId;
+	private Long userId;
+	private String username;
+	private String content;
+	private LocalDateTime createdAt;
+	private Long likeCount;
+	private Long replyCount;
+
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/CommentUpdateResponseDto.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/CommentUpdateResponseDto.java
@@ -13,12 +13,14 @@ public class CommentUpdateResponseDto {
 
 	private Long commentId;
 	private Long userId;
+	private String username;
 	private String content;
 
-	public static CommentUpdateResponseDto of(Long commentId, Long userId, String content) {
+	public static CommentUpdateResponseDto of(Long commentId, Long userId, String username, String content) {
 		return CommentUpdateResponseDto.builder()
 			.commentId(commentId)
 			.userId(userId)
+			.username(username)
 			.content(content)
 			.build();
 	}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/PageResponseDto.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/PageResponseDto.java
@@ -1,0 +1,29 @@
+package com.linkeleven.msa.interaction.application.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PageResponseDto<T> {
+
+	private List<T> queryList;
+	private boolean hasNext;
+
+	public static <T> PageResponseDto<T> from(Slice<T> slice) {
+		return PageResponseDto.<T>builder()
+			.queryList(slice.getContent())
+			.hasNext(slice.hasNext())
+			.build();
+	}
+
+}
+

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/ReplyCreateResponseDto.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/ReplyCreateResponseDto.java
@@ -14,13 +14,15 @@ public class ReplyCreateResponseDto {
 	private Long replyId;
 	private Long commentId;
 	private Long userId;
+	private String username;
 	private String content;
 
-	public static ReplyCreateResponseDto of(Long replyId, Long commentId, Long userId, String content) {
+	public static ReplyCreateResponseDto of(Long replyId, Long commentId, Long userId, String username, String content) {
 		return ReplyCreateResponseDto.builder()
 			.replyId(replyId)
 			.commentId(commentId)
 			.userId(userId)
+			.username(username)
 			.content(content)
 			.build();
 	}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/ReplyQueryResponseDto.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/ReplyQueryResponseDto.java
@@ -1,0 +1,23 @@
+package com.linkeleven.msa.interaction.application.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReplyQueryResponseDto {
+
+	private Long replyId;
+	private Long userId;
+	private String username;
+	private String content;
+	private LocalDateTime createdAt;
+	private Long likeCount;
+
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/ReplyUpdateResponseDto.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/ReplyUpdateResponseDto.java
@@ -14,13 +14,15 @@ public class ReplyUpdateResponseDto {
 	private Long replyId;
 	private Long commentId;
 	private Long userId;
+	private String username;
 	private String content;
 
-	public static ReplyUpdateResponseDto of(Long replyId, Long commentId, Long userId, String content) {
+	public static ReplyUpdateResponseDto of(Long replyId, Long commentId, Long userId, String username, String content) {
 		return ReplyUpdateResponseDto.builder()
 			.replyId(replyId)
 			.commentId(commentId)
 			.userId(userId)
+			.username(username)
 			.content(content)
 			.build();
 	}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/external/UserInfoResponseDto.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/dto/external/UserInfoResponseDto.java
@@ -1,0 +1,14 @@
+package com.linkeleven.msa.interaction.application.dto.external;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserInfoResponseDto {
+
+	private String username;
+
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/CommentQueryService.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/CommentQueryService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.linkeleven.msa.interaction.application.dto.CommentQueryResponseDto;
 import com.linkeleven.msa.interaction.domain.repository.CommentRepository;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CommentQueryService {
 
 	private final CommentRepository commentRepository;

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/CommentQueryService.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/CommentQueryService.java
@@ -1,0 +1,25 @@
+package com.linkeleven.msa.interaction.application.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.linkeleven.msa.interaction.application.dto.CommentQueryResponseDto;
+import com.linkeleven.msa.interaction.domain.repository.CommentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentQueryService {
+
+	private final CommentRepository commentRepository;
+	public List<CommentQueryResponseDto> getCommentsWithCursor(
+		Long feedId, Long cursorId, LocalDateTime cursorCreatedAt, Long cursorLikeCount,
+		int pageSize, String sortByEnum)
+	{
+		return commentRepository.findCommentByFeedWithCursor(feedId, cursorId, pageSize, sortByEnum,
+			cursorLikeCount, cursorCreatedAt);
+	}
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/CommentQueryService.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/CommentQueryService.java
@@ -1,8 +1,8 @@
 package com.linkeleven.msa.interaction.application.service;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class CommentQueryService {
 
 	private final CommentRepository commentRepository;
-	public List<CommentQueryResponseDto> getCommentsWithCursor(
+	public Slice<CommentQueryResponseDto> getCommentsWithCursor(
 		Long feedId, Long cursorId, LocalDateTime cursorCreatedAt, Long cursorLikeCount,
 		int pageSize, String sortByEnum)
 	{

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/LikeService.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/LikeService.java
@@ -56,12 +56,24 @@ public class LikeService {
 
 	private void validateTarget(Long targetId, ContentType contentType) {
 		boolean isValid = switch (contentType) {
-			case FEED -> feedClient.checkFeedExists(targetId);
-			case COMMENT -> validationService.existsComment(targetId);
-			case REPLY -> validationService.existsReply(targetId);
+			case FEED -> validateFeed(targetId);
+			case COMMENT -> validateComment(targetId);
+			case REPLY -> validateReply(targetId);
 		};
 		if (!isValid) {
 			throw new CustomException(ErrorCode.TARGET_NOT_FOUND);
 		}
+	}
+
+	private boolean validateReply(Long targetId) {
+		return validationService.existsReply(targetId);
+	}
+
+	private boolean validateComment(Long targetId) {
+		return validationService.existsComment(targetId);
+	}
+
+	private boolean validateFeed(Long targetId) {
+		return feedClient.checkFeedExists(targetId);
 	}
 }

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/ReplyQueryService.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/ReplyQueryService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.linkeleven.msa.interaction.application.dto.ReplyQueryResponseDto;
 import com.linkeleven.msa.interaction.domain.repository.ReplyRepository;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReplyQueryService {
 
 	private final ReplyRepository replyRepository;

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/ReplyQueryService.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/ReplyQueryService.java
@@ -1,0 +1,26 @@
+package com.linkeleven.msa.interaction.application.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.linkeleven.msa.interaction.application.dto.ReplyQueryResponseDto;
+import com.linkeleven.msa.interaction.domain.repository.ReplyRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReplyQueryService {
+
+	private final ReplyRepository replyRepository;
+
+	public List<ReplyQueryResponseDto> getRepliesWithCursor(
+		Long commentId, Long cursorId, LocalDateTime cursorCreatedAt, Long cursorLikeCount,
+		int pageSize, String sortByEnum)
+	{
+		return replyRepository.findReplyByCommentWithCursor(commentId, cursorId, pageSize, sortByEnum,
+			cursorLikeCount, cursorCreatedAt);
+	}
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/ReplyQueryService.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/ReplyQueryService.java
@@ -1,8 +1,8 @@
 package com.linkeleven.msa.interaction.application.service;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +18,7 @@ public class ReplyQueryService {
 
 	private final ReplyRepository replyRepository;
 
-	public List<ReplyQueryResponseDto> getRepliesWithCursor(
+	public Slice<ReplyQueryResponseDto> getRepliesWithCursor(
 		Long commentId, Long cursorId, LocalDateTime cursorCreatedAt, Long cursorLikeCount,
 		int pageSize, String sortByEnum)
 	{

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/ReplyService.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/application/service/ReplyService.java
@@ -6,10 +6,12 @@ import org.springframework.stereotype.Service;
 
 import com.linkeleven.msa.interaction.application.dto.ReplyCreateResponseDto;
 import com.linkeleven.msa.interaction.application.dto.ReplyUpdateResponseDto;
+import com.linkeleven.msa.interaction.application.dto.external.UserInfoResponseDto;
 import com.linkeleven.msa.interaction.domain.model.entity.Reply;
 import com.linkeleven.msa.interaction.domain.model.vo.ContentDetails;
 import com.linkeleven.msa.interaction.domain.repository.ReplyRepository;
 import com.linkeleven.msa.interaction.domain.service.ValidationService;
+import com.linkeleven.msa.interaction.infrastructure.client.AuthClient;
 import com.linkeleven.msa.interaction.libs.exception.CustomException;
 import com.linkeleven.msa.interaction.libs.exception.ErrorCode;
 import com.linkeleven.msa.interaction.presentation.dto.ReplyCreateRequestDto;
@@ -25,16 +27,19 @@ public class ReplyService {
 
 	private final ReplyRepository replyRepository;
 	private final ValidationService validationService;
+	private final AuthClient authClient;
 
 	public ReplyCreateResponseDto createReply(Long userId, Long commentId, ReplyCreateRequestDto requestDto) {
+		UserInfoResponseDto userInfo = getUsername(userId);
 		checkCommentExists(commentId);
-		ContentDetails contentDetails = ContentDetails.of(requestDto.getContent(), userId);
+		ContentDetails contentDetails = ContentDetails.of(requestDto.getContent(), userId, userInfo.getUsername());
 		Reply reply = Reply.of(contentDetails, commentId);
 		replyRepository.save(reply);
 		return ReplyCreateResponseDto.of(
 			reply.getId(),
 			reply.getCommentId(),
 			reply.getContentDetails().getUserId(),
+			reply.getContentDetails().getUsername(),
 			reply.getContentDetails().getContent());
 	}
 
@@ -47,6 +52,7 @@ public class ReplyService {
 			reply.getId(),
 			reply.getCommentId(),
 			reply.getContentDetails().getUserId(),
+			reply.getContentDetails().getUsername(),
 			reply.getContentDetails().getContent());
 	}
 
@@ -98,5 +104,9 @@ public class ReplyService {
 	private Reply getReply(Long replyId) {
 		return replyRepository.findById(replyId)
 			.orElseThrow(() -> new CustomException(ErrorCode.REPLY_NOT_FOUND));
+	}
+
+	private UserInfoResponseDto getUsername(Long userId) {
+		return authClient.getUsername(userId);
 	}
 }

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/entity/Comment.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/entity/Comment.java
@@ -32,7 +32,8 @@ public class Comment extends BaseTime{
 	@Embedded
 	@AttributeOverrides({
 		@AttributeOverride(name = "content", column = @Column(name = "content", nullable = false)),
-		@AttributeOverride(name = "userId", column = @Column(name = "userId", nullable = false, updatable = false))
+		@AttributeOverride(name = "userId", column = @Column(name = "userId", nullable = false, updatable = false)),
+		@AttributeOverride(name = "username", column = @Column(name = "username", nullable = false))
 	})
 	private ContentDetails contentDetails;
 
@@ -61,12 +62,12 @@ public class Comment extends BaseTime{
 	}
 
 	public void updateComment(String newContent) {
-		this.contentDetails = ContentDetails.of(newContent, this.contentDetails.getUserId());
+		this.contentDetails = ContentDetails.of(newContent, this.contentDetails.getUserId(), this.contentDetails.getUsername());
 	}
 
 	public void deleteComment() {
 			this.setDeletedAt(LocalDateTime.now());
-			this.contentDetails = ContentDetails.of("삭제된 댓글입니다.", this.contentDetails.getUserId());
+			this.contentDetails = ContentDetails.of("삭제된 댓글입니다.", this.contentDetails.getUserId(), this.contentDetails.getUsername());
 	}
 
 

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/entity/Reply.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/entity/Reply.java
@@ -61,7 +61,7 @@ public class Reply extends BaseTime{
 	}
 
 	public void updateReply(String newContent) {
-		this.contentDetails = ContentDetails.of(newContent, this.contentDetails.getUserId());
+		this.contentDetails = ContentDetails.of(newContent, this.contentDetails.getUserId(), this.contentDetails.getUsername());
 	}
 
 	public void deleteReply() {

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/vo/ContentDetails.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/model/vo/ContentDetails.java
@@ -19,12 +19,14 @@ public class ContentDetails {
 
 	private Long userId;
 
-	public static ContentDetails of(String content, Long userId) {
-		validate(content, userId);
-		return new ContentDetails(content, userId);
+	private String username;
+
+	public static ContentDetails of(String content, Long userId, String username) {
+		validate(content, userId, username);
+		return new ContentDetails(content, userId, username);
 	}
 
-	private static void validate(String content, Long userId) {
+	private static void validate(String content, Long userId, String username) {
 		if (content == null || content.isBlank()) {
 			throw new CustomException(ErrorCode.CONTENT_CANNOT_BE_NULL_OR_EMPTY);
 		}
@@ -33,6 +35,9 @@ public class ContentDetails {
 		}
 		if (userId == null || userId <= 0) {
 			throw new CustomException(ErrorCode.INVALID_USERID);
+		}
+		if (username == null || username.isBlank()) {
+			throw new CustomException(ErrorCode.USERNAME_CANNOT_BE_NULL_OR_EMPTY);
 		}
 	}
 

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/CommentRepository.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/CommentRepository.java
@@ -1,9 +1,12 @@
 package com.linkeleven.msa.interaction.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import com.linkeleven.msa.interaction.domain.model.entity.Comment;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> , CommentRepositoryCustom {
 	boolean existsByIdAndDeletedAtIsNull(Long commentId);
+
 }

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/CommentRepositoryCustom.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/CommentRepositoryCustom.java
@@ -3,11 +3,8 @@ package com.linkeleven.msa.interaction.domain.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.data.repository.NoRepositoryBean;
-
 import com.linkeleven.msa.interaction.application.dto.CommentQueryResponseDto;
 
-@NoRepositoryBean
 public interface CommentRepositoryCustom {
 
 	List<CommentQueryResponseDto> findCommentByFeedWithCursor(

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/CommentRepositoryCustom.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/CommentRepositoryCustom.java
@@ -1,13 +1,14 @@
 package com.linkeleven.msa.interaction.domain.repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
+
+import org.springframework.data.domain.Slice;
 
 import com.linkeleven.msa.interaction.application.dto.CommentQueryResponseDto;
 
 public interface CommentRepositoryCustom {
 
-	List<CommentQueryResponseDto> findCommentByFeedWithCursor(
+	Slice<CommentQueryResponseDto> findCommentByFeedWithCursor(
 		Long feedId, Long cursorId, int pageSize, String sortByEnum, Long cursorLikeCount, LocalDateTime cursorCreatedAt);
 
 }

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/CommentRepositoryCustom.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/CommentRepositoryCustom.java
@@ -1,0 +1,16 @@
+package com.linkeleven.msa.interaction.domain.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.repository.NoRepositoryBean;
+
+import com.linkeleven.msa.interaction.application.dto.CommentQueryResponseDto;
+
+@NoRepositoryBean
+public interface CommentRepositoryCustom {
+
+	List<CommentQueryResponseDto> findCommentByFeedWithCursor(
+		Long feedId, Long cursorId, int pageSize, String sortByEnum, Long cursorLikeCount, LocalDateTime cursorCreatedAt);
+
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/ReplyRepository.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/ReplyRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.linkeleven.msa.interaction.domain.model.entity.Reply;
 
-public interface ReplyRepository extends JpaRepository<Reply, Long> {
+public interface ReplyRepository extends JpaRepository<Reply, Long> , ReplyRepositoryCustom{
 }

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/ReplyRepositoryCustom.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/ReplyRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.linkeleven.msa.interaction.domain.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.linkeleven.msa.interaction.application.dto.ReplyQueryResponseDto;
+
+public interface ReplyRepositoryCustom {
+
+	List<ReplyQueryResponseDto> findReplyByCommentWithCursor(
+		Long commentId, Long cursorId, int pageSize, String sortByEnum, Long cursorLikeCount, LocalDateTime cursorCreatedAt);
+
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/ReplyRepositoryCustom.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/domain/repository/ReplyRepositoryCustom.java
@@ -1,13 +1,14 @@
 package com.linkeleven.msa.interaction.domain.repository;
 
 import java.time.LocalDateTime;
-import java.util.List;
+
+import org.springframework.data.domain.Slice;
 
 import com.linkeleven.msa.interaction.application.dto.ReplyQueryResponseDto;
 
 public interface ReplyRepositoryCustom {
 
-	List<ReplyQueryResponseDto> findReplyByCommentWithCursor(
+	Slice<ReplyQueryResponseDto> findReplyByCommentWithCursor(
 		Long commentId, Long cursorId, int pageSize, String sortByEnum, Long cursorLikeCount, LocalDateTime cursorCreatedAt);
 
 }

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/infrastructure/client/AuthClient.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/infrastructure/client/AuthClient.java
@@ -1,0 +1,15 @@
+package com.linkeleven.msa.interaction.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.linkeleven.msa.interaction.application.dto.external.UserInfoResponseDto;
+
+@FeignClient(name = "auth-service")
+public interface AuthClient {
+
+	@GetMapping("/external/auth/{userId}")
+	UserInfoResponseDto getUsername(@PathVariable Long userId);
+
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/infrastructure/config/QueryDslConfig.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package com.linkeleven.msa.interaction.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class QueryDslConfig {
+
+	@Bean
+	public JPAQueryFactory queryFactory(EntityManager entityManager) {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/infrastructure/repository/CommentRepositoryImpl.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/infrastructure/repository/CommentRepositoryImpl.java
@@ -1,0 +1,91 @@
+package com.linkeleven.msa.interaction.infrastructure.repository;
+
+import static com.linkeleven.msa.interaction.domain.model.entity.QComment.*;
+import static com.linkeleven.msa.interaction.domain.model.entity.QLike.*;
+import static com.linkeleven.msa.interaction.domain.model.entity.QReply.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.linkeleven.msa.interaction.application.dto.CommentQueryResponseDto;
+import com.linkeleven.msa.interaction.domain.repository.CommentRepositoryCustom;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<CommentQueryResponseDto> findCommentByFeedWithCursor(
+		Long feedId, Long cursorId, int pageSize, String sortBy,
+		Long cursorLikeCount, LocalDateTime cursorCreatedAt)
+	{
+		return queryFactory.select(Projections.constructor(CommentQueryResponseDto.class,
+				comment.id,
+				comment.contentDetails.userId,
+				comment.contentDetails.username,
+				comment.contentDetails.content,
+				comment.createdAt,
+				like.count().as("likeCount"),
+				reply.count().as("replyCount")
+			))
+			.from(comment)
+			.leftJoin(like).on(like.target.targetId.eq(comment.id))
+			.leftJoin(reply).on(reply.commentId.eq(comment.id))
+			.where(comment.feedId.eq(feedId),
+				isNotDeleted(),
+				// isNotReported(),
+				cursorCondition(cursorId, sortBy, cursorLikeCount, cursorCreatedAt))
+			.groupBy(comment.id)
+			.orderBy(getOrderSpecifier(sortBy), comment.id.desc())
+			.limit(pageSize)
+			.fetch();
+	}
+
+	private BooleanExpression cursorCondition(Long cursorId, String sortBy, Long cursorLikeCount, LocalDateTime cursorCreatedAt) {
+		return "like".equalsIgnoreCase(sortBy) ?
+			cursorLikeCondition(cursorId, cursorLikeCount) :
+			cursorCreatedAtCondition(cursorId, cursorCreatedAt);
+	}
+
+	private BooleanExpression cursorLikeCondition(Long cursorId, Long cursorLikeCount) {
+		if (cursorId == null || cursorLikeCount == null) {
+			return null;
+		}
+		return like.count().lt(cursorLikeCount)
+			.or(like.count().eq(cursorLikeCount).and(comment.id.gt(cursorId)));
+	}
+
+	private BooleanExpression cursorCreatedAtCondition(Long cursorId, LocalDateTime cursorCreatedAt) {
+		if (cursorId == null || cursorCreatedAt == null) {
+			return null;
+		}
+		return comment.createdAt.lt(cursorCreatedAt)
+			.or(comment.createdAt.eq(cursorCreatedAt).and(comment.id.gt(cursorId)));
+	}
+
+	private OrderSpecifier<?> getOrderSpecifier(String sortBy) {
+		if ("like".equalsIgnoreCase(sortBy)) {
+			return like.count().desc();
+		} else {
+			return comment.createdAt.desc();
+		}
+	}
+
+	private BooleanExpression isNotDeleted() {
+		return comment.deletedAt.isNull();
+	}
+
+	// private BooleanExpression isNotReported() {
+	// 	return comment.isReported.eq(false);
+	// }
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/infrastructure/repository/ReplyRepositoryImpl.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/infrastructure/repository/ReplyRepositoryImpl.java
@@ -1,0 +1,87 @@
+package com.linkeleven.msa.interaction.infrastructure.repository;
+
+import static com.linkeleven.msa.interaction.domain.model.entity.QLike.*;
+import static com.linkeleven.msa.interaction.domain.model.entity.QReply.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.linkeleven.msa.interaction.application.dto.ReplyQueryResponseDto;
+import com.linkeleven.msa.interaction.domain.repository.ReplyRepositoryCustom;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ReplyRepositoryImpl implements ReplyRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<ReplyQueryResponseDto> findReplyByCommentWithCursor(
+		Long commentId, Long cursorId, int pageSize,
+		String sortByEnum, Long cursorLikeCount, LocalDateTime cursorCreatedAt)
+	{
+		return queryFactory.select(Projections.constructor(ReplyQueryResponseDto.class,
+				reply.id,
+				reply.contentDetails.userId,
+				reply.contentDetails.username,
+				reply.contentDetails.content,
+				reply.createdAt,
+				like.count().as("likeCount")
+			))
+			.from(reply)
+			.leftJoin(like).on(like.target.targetId.eq(reply.id))
+			.where(reply.commentId.eq(commentId),
+				isNotDeleted(),
+				// isNotReported(),
+				cursorCondition(cursorId, sortByEnum, cursorLikeCount, cursorCreatedAt))
+			.groupBy(reply.id)
+			.orderBy(getOrderSpecifier(sortByEnum), reply.id.desc())
+			.limit(pageSize)
+			.fetch();
+	}
+
+	private BooleanExpression cursorCondition(Long cursorId, String sortBy, Long cursorLikeCount, LocalDateTime cursorCreatedAt) {
+		return "like".equalsIgnoreCase(sortBy) ?
+			cursorLikeCondition(cursorId, cursorLikeCount) :
+			cursorCreatedAtCondition(cursorId, cursorCreatedAt);
+	}
+
+	private BooleanExpression cursorLikeCondition(Long cursorId, Long cursorLikeCount) {
+		if (cursorId == null || cursorLikeCount == null) {
+			return null;
+		}
+		return like.count().lt(cursorLikeCount)
+			.or(like.count().eq(cursorLikeCount).and(reply.id.gt(cursorId)));
+	}
+
+	private BooleanExpression cursorCreatedAtCondition(Long cursorId, LocalDateTime cursorCreatedAt) {
+		if (cursorId == null || cursorCreatedAt == null) {
+			return null;
+		}
+		return reply.createdAt.lt(cursorCreatedAt)
+			.or(reply.createdAt.eq(cursorCreatedAt).and(reply.id.gt(cursorId)));
+	}
+
+	private OrderSpecifier<?> getOrderSpecifier(String sortBy) {
+		if ("like".equalsIgnoreCase(sortBy)) {
+			return like.count().desc();
+		} else {
+			return reply.createdAt.desc();
+		}
+	}
+	private BooleanExpression isNotDeleted() {
+		return reply.deletedAt.isNull();
+	}
+
+	// private BooleanExpression isNotReported() {
+	// 	return reply.isReported.eq(false);
+	// }
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/libs/exception/ErrorCode.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/libs/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 	/*  400 BAD_REQUEST : 잘못된 요청  */
 	EXPIRED_TOKEN(400, "만료된 토큰입니다."),
 	CONTENT_CANNOT_BE_NULL_OR_EMPTY(400, "댓글 내용은 null 또는 빈 값일 수 없습니다."),
+	USERNAME_CANNOT_BE_NULL_OR_EMPTY(400, "유저네임은 null 또는 빈 값일 수 없습니다."),
 	CONTENT_TYPE_CANNOT_BE_NULL(400, "컨텐츠 타입은 null일 수 없습니다."),
 	CONTENT_TOO_LONG(400, "100자 이내로 작성해야 합니다."),
 	INVALID_USERID(400, "유효하지않은 유저ID입니다."),

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/controller/CommentQueryController.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/controller/CommentQueryController.java
@@ -1,8 +1,8 @@
 package com.linkeleven.msa.interaction.presentation.controller;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.linkeleven.msa.interaction.application.dto.CommentQueryResponseDto;
+import com.linkeleven.msa.interaction.application.dto.PageResponseDto;
 import com.linkeleven.msa.interaction.application.service.CommentQueryService;
 import com.linkeleven.msa.interaction.libs.dto.SuccessResponseDto;
 import com.linkeleven.msa.interaction.presentation.enums.SortBy;
@@ -26,7 +27,7 @@ public class CommentQueryController {
 	private final CommentQueryService commentQueryService;
 
 	@GetMapping("/{feedId}")
-	public ResponseEntity<SuccessResponseDto<List<CommentQueryResponseDto>>> getCommentList(
+	public ResponseEntity<SuccessResponseDto<PageResponseDto<CommentQueryResponseDto>>> getCommentList(
 		@PathVariable Long feedId,
 		@RequestParam(required = false) Long cursorId,
 		@RequestParam(required = false) LocalDateTime cursorCreatedAt,
@@ -35,9 +36,12 @@ public class CommentQueryController {
 		@RequestParam(required = false) String sortBy)
 	{
 		String sortByEnum = String.valueOf(SortBy.fromString(sortBy));
-		List<CommentQueryResponseDto> responseDtoList =  commentQueryService.getCommentsWithCursor(
+		Slice<CommentQueryResponseDto> slice = commentQueryService.getCommentsWithCursor(
 			feedId, cursorId, cursorCreatedAt, cursorLikeCount, pageSize, sortByEnum);
+
+		PageResponseDto<CommentQueryResponseDto> responseDto = PageResponseDto.from(slice);
+
 		return ResponseEntity.ok()
-			.body(SuccessResponseDto.success("조회 성공", responseDtoList));
+			.body(SuccessResponseDto.success("조회 성공", responseDto));
 	}
 }

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/controller/CommentQueryController.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/controller/CommentQueryController.java
@@ -1,0 +1,43 @@
+package com.linkeleven.msa.interaction.presentation.controller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.linkeleven.msa.interaction.application.dto.CommentQueryResponseDto;
+import com.linkeleven.msa.interaction.application.service.CommentQueryService;
+import com.linkeleven.msa.interaction.libs.dto.SuccessResponseDto;
+import com.linkeleven.msa.interaction.presentation.enums.SortBy;
+
+import jakarta.validation.constraints.Max;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/comments")
+@RequiredArgsConstructor
+public class CommentQueryController {
+
+	private final CommentQueryService commentQueryService;
+
+	@GetMapping("/{feedId}")
+	public ResponseEntity<SuccessResponseDto<List<CommentQueryResponseDto>>> getCommentList(
+		@PathVariable Long feedId,
+		@RequestParam(required = false) Long cursorId,
+		@RequestParam(required = false) LocalDateTime cursorCreatedAt,
+		@RequestParam(required = false) Long cursorLikeCount,
+		@RequestParam(defaultValue = "30") @Max(50) int pageSize,
+		@RequestParam(required = false) String sortBy)
+	{
+		String sortByEnum = String.valueOf(SortBy.fromString(sortBy));
+		List<CommentQueryResponseDto> responseDtoList =  commentQueryService.getCommentsWithCursor(
+			feedId, cursorId, cursorCreatedAt, cursorLikeCount, pageSize, sortByEnum);
+		return ResponseEntity.ok()
+			.body(SuccessResponseDto.success("조회 성공", responseDtoList));
+	}
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/controller/LikeController.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/controller/LikeController.java
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,7 +12,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.linkeleven.msa.interaction.application.service.LikeService;
 import com.linkeleven.msa.interaction.domain.model.enums.ContentType;
 import com.linkeleven.msa.interaction.libs.dto.SuccessResponseDto;
-import com.linkeleven.msa.interaction.presentation.dto.LikeRequestDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,28 +22,63 @@ public class LikeController {
 
 	private final LikeService likeService;
 
-	@PostMapping("/{targetId}")
-	public ResponseEntity<SuccessResponseDto<Void>> createLike(
+	@PostMapping("/feeds/{feedId}")
+	public ResponseEntity<SuccessResponseDto<Void>> createFeedLike(
 		@RequestHeader("X-User-Id") Long userId,
-		@PathVariable Long targetId,
-		@RequestBody LikeRequestDto requestDto
+		@PathVariable Long feedId
 	) {
-		ContentType contentType = requestDto.validateContentType();
-		likeService.createLike(userId, targetId, contentType);
+		likeService.createLike(userId, feedId, ContentType.FEED);
 		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(SuccessResponseDto.success("좋아요."));
+			.body(SuccessResponseDto.success("게시글 좋아요."));
 	}
 
-	@DeleteMapping("/{targetId}")
-	public ResponseEntity<SuccessResponseDto<Void>> deleteLike(
+	@DeleteMapping("/feeds/{feedId}")
+	public ResponseEntity<SuccessResponseDto<Void>> deleteFeedLike(
 		@RequestHeader("X-User-Id") Long userId,
-		@PathVariable Long targetId,
-		@RequestBody LikeRequestDto requestDto
+		@PathVariable Long feedId
 	) {
-		ContentType contentType = requestDto.validateContentType();
-		likeService.cancelLike(userId, targetId, contentType);
+		likeService.cancelLike(userId, feedId, ContentType.FEED);
 		return ResponseEntity.ok()
-			.body(SuccessResponseDto.success("좋아요 취소."));
+			.body(SuccessResponseDto.success("게시글 좋아요 취소."));
 	}
 
+	@PostMapping("/comments/{commentId}")
+	public ResponseEntity<SuccessResponseDto<Void>> createCommentLike(
+		@RequestHeader("X-User-Id") Long userId,
+		@PathVariable Long commentId
+	) {
+		likeService.createLike(userId, commentId, ContentType.COMMENT);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(SuccessResponseDto.success("댓글 좋아요."));
+	}
+
+	@DeleteMapping("/comments/{commentId}")
+	public ResponseEntity<SuccessResponseDto<Void>> deleteCommentLike(
+		@RequestHeader("X-User-Id") Long userId,
+		@PathVariable Long commentId
+	) {
+		likeService.cancelLike(userId, commentId, ContentType.COMMENT);
+		return ResponseEntity.ok()
+			.body(SuccessResponseDto.success("댓글 좋아요 취소."));
+	}
+
+	@PostMapping("/replies/{replyId}")
+	public ResponseEntity<SuccessResponseDto<Void>> createReplyLike(
+		@RequestHeader("X-User-Id") Long userId,
+		@PathVariable Long replyId
+	) {
+		likeService.createLike(userId, replyId, ContentType.REPLY);
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(SuccessResponseDto.success("대댓글 좋아요."));
+	}
+
+	@DeleteMapping("/replies/{replyId}")
+	public ResponseEntity<SuccessResponseDto<Void>> deleteReplyLike(
+		@RequestHeader("X-User-Id") Long userId,
+		@PathVariable Long replyId
+	) {
+		likeService.cancelLike(userId, replyId, ContentType.REPLY);
+		return ResponseEntity.ok()
+			.body(SuccessResponseDto.success("대댓글 좋아요 취소."));
+	}
 }

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/controller/ReplyQueryController.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/controller/ReplyQueryController.java
@@ -1,0 +1,46 @@
+package com.linkeleven.msa.interaction.presentation.controller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.linkeleven.msa.interaction.application.dto.ReplyQueryResponseDto;
+import com.linkeleven.msa.interaction.application.service.ReplyQueryService;
+import com.linkeleven.msa.interaction.libs.dto.SuccessResponseDto;
+import com.linkeleven.msa.interaction.presentation.enums.SortBy;
+
+import jakarta.validation.constraints.Max;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/comments")
+@RequiredArgsConstructor
+public class ReplyQueryController {
+
+	private final ReplyQueryService replyQueryService;
+
+	@GetMapping("/{commentId}/replies")
+	public ResponseEntity<SuccessResponseDto<List<ReplyQueryResponseDto>>> getReplyList(
+		@PathVariable Long commentId,
+		@RequestParam(required = false) Long cursorId,
+		@RequestParam(required = false) LocalDateTime cursorCreatedAt,
+		@RequestParam(required = false) Long cursorLikeCount,
+		@RequestParam(defaultValue = "30") @Max(50) int pageSize,
+		@RequestParam(required = false) String sortBy)
+	{
+		String sortByEnum = String.valueOf(SortBy.fromString(sortBy));
+		List<ReplyQueryResponseDto> responseDtoList = replyQueryService.getRepliesWithCursor(
+			commentId, cursorId, cursorCreatedAt, cursorLikeCount, pageSize, sortByEnum
+		);
+		return ResponseEntity.ok()
+			.body(SuccessResponseDto.success("조회 성공", responseDtoList));
+	}
+
+
+}

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/controller/ReplyQueryController.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/controller/ReplyQueryController.java
@@ -1,8 +1,8 @@
 package com.linkeleven.msa.interaction.presentation.controller;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.linkeleven.msa.interaction.application.dto.PageResponseDto;
 import com.linkeleven.msa.interaction.application.dto.ReplyQueryResponseDto;
 import com.linkeleven.msa.interaction.application.service.ReplyQueryService;
 import com.linkeleven.msa.interaction.libs.dto.SuccessResponseDto;
@@ -26,7 +27,7 @@ public class ReplyQueryController {
 	private final ReplyQueryService replyQueryService;
 
 	@GetMapping("/{commentId}/replies")
-	public ResponseEntity<SuccessResponseDto<List<ReplyQueryResponseDto>>> getReplyList(
+	public ResponseEntity<SuccessResponseDto<PageResponseDto<ReplyQueryResponseDto>>> getReplyList(
 		@PathVariable Long commentId,
 		@RequestParam(required = false) Long cursorId,
 		@RequestParam(required = false) LocalDateTime cursorCreatedAt,
@@ -35,12 +36,13 @@ public class ReplyQueryController {
 		@RequestParam(required = false) String sortBy)
 	{
 		String sortByEnum = String.valueOf(SortBy.fromString(sortBy));
-		List<ReplyQueryResponseDto> responseDtoList = replyQueryService.getRepliesWithCursor(
+		Slice<ReplyQueryResponseDto> slice = replyQueryService.getRepliesWithCursor(
 			commentId, cursorId, cursorCreatedAt, cursorLikeCount, pageSize, sortByEnum
 		);
+
+		PageResponseDto<ReplyQueryResponseDto> responseDto = PageResponseDto.from(slice);
+
 		return ResponseEntity.ok()
-			.body(SuccessResponseDto.success("조회 성공", responseDtoList));
+			.body(SuccessResponseDto.success("조회 성공", responseDto));
 	}
-
-
 }

--- a/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/enums/SortBy.java
+++ b/interaction/src/main/java/com/linkeleven/msa/interaction/presentation/enums/SortBy.java
@@ -1,0 +1,13 @@
+package com.linkeleven.msa.interaction.presentation.enums;
+
+public enum SortBy {
+	LIKE,
+	CREATED_AT;
+
+	public static SortBy fromString(String input) {
+		if (input == null || !input.equalsIgnoreCase("LIKE")) {
+			return CREATED_AT;
+		}
+		return LIKE;
+	}
+}

--- a/interaction/src/test/java/com/linkeleven/msa/interaction/application/service/CommentServiceTest.java
+++ b/interaction/src/test/java/com/linkeleven/msa/interaction/application/service/CommentServiceTest.java
@@ -12,7 +12,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.linkeleven.msa.interaction.application.dto.CommentCreateResponseDto;
+import com.linkeleven.msa.interaction.application.dto.external.UserInfoResponseDto;
 import com.linkeleven.msa.interaction.domain.repository.CommentRepository;
+import com.linkeleven.msa.interaction.infrastructure.client.AuthClient;
 import com.linkeleven.msa.interaction.infrastructure.client.FeedClient;
 import com.linkeleven.msa.interaction.presentation.dto.CommentCreateRequestDto;
 import com.linkeleven.msa.interaction.presentation.dto.CommentUpdateRequestDto;
@@ -30,6 +32,9 @@ class CommentServiceTest {
 	@MockitoBean
 	private FeedClient feedClient;
 
+	@MockitoBean
+	private AuthClient authClient;
+
 	private Long userId;
 	private Long feedId;
 
@@ -39,6 +44,9 @@ class CommentServiceTest {
 		feedId = 100L;
 
 		Mockito.when(feedClient.checkFeedExists(100L)).thenReturn(true);
+
+		UserInfoResponseDto userInfo = new UserInfoResponseDto("username");
+		Mockito.when(authClient.getUsername(1L)).thenReturn(userInfo);
 	}
 
 	@Test

--- a/interaction/src/test/java/com/linkeleven/msa/interaction/application/service/CommentServiceTest.java
+++ b/interaction/src/test/java/com/linkeleven/msa/interaction/application/service/CommentServiceTest.java
@@ -60,6 +60,7 @@ class CommentServiceTest {
 
 		assertThat(responseDto.getCommentId()).isNotNull();
 		assertThat(responseDto.getContent()).isEqualTo(content);
+		assertThat(responseDto.getUsername()).isEqualTo("username");
 	}
 
 	@Test

--- a/interaction/src/test/java/com/linkeleven/msa/interaction/application/service/ReplyServiceTest.java
+++ b/interaction/src/test/java/com/linkeleven/msa/interaction/application/service/ReplyServiceTest.java
@@ -13,8 +13,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.linkeleven.msa.interaction.application.dto.CommentCreateResponseDto;
 import com.linkeleven.msa.interaction.application.dto.ReplyCreateResponseDto;
+import com.linkeleven.msa.interaction.application.dto.external.UserInfoResponseDto;
 import com.linkeleven.msa.interaction.domain.repository.ReplyRepository;
 import com.linkeleven.msa.interaction.domain.service.ValidationService;
+import com.linkeleven.msa.interaction.infrastructure.client.AuthClient;
 import com.linkeleven.msa.interaction.infrastructure.client.FeedClient;
 import com.linkeleven.msa.interaction.presentation.dto.CommentCreateRequestDto;
 import com.linkeleven.msa.interaction.presentation.dto.ReplyCreateRequestDto;
@@ -39,6 +41,9 @@ class ReplyServiceTest {
 	@MockitoBean
 	private FeedClient feedClient;
 
+	@MockitoBean
+	private AuthClient authClient;
+
 	private Long userId;
 	private Long commentId;
 
@@ -48,6 +53,9 @@ class ReplyServiceTest {
 		Long feedId = 50L;
 
 		Mockito.when(feedClient.checkFeedExists(50L)).thenReturn(true);
+
+		UserInfoResponseDto userInfo = new UserInfoResponseDto("username");
+		Mockito.when(authClient.getUsername(1L)).thenReturn(userInfo);
 
 		String content = "테스트";
 		CommentCreateRequestDto requestDto = new CommentCreateRequestDto();

--- a/interaction/src/test/java/com/linkeleven/msa/interaction/infrastructure/repository/CommentRepositoryImplTest.java
+++ b/interaction/src/test/java/com/linkeleven/msa/interaction/infrastructure/repository/CommentRepositoryImplTest.java
@@ -5,13 +5,17 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.linkeleven.msa.interaction.application.dto.CommentQueryResponseDto;
+import com.linkeleven.msa.interaction.domain.model.entity.Comment;
+import com.linkeleven.msa.interaction.domain.model.vo.ContentDetails;
 import com.linkeleven.msa.interaction.domain.repository.CommentRepository;
 
 @SpringBootTest
@@ -20,6 +24,14 @@ class CommentRepositoryImplTest {
 
 	@Autowired
 	private CommentRepository commentRepository;
+
+	@BeforeEach
+	void setUp() {
+		Comment comment1 = Comment.of(ContentDetails.of("테스트1", 1L, "1"), 1L);
+		Comment comment2 = Comment.of(ContentDetails.of("테스트2", 2L, "2"), 1L);
+
+		commentRepository.saveAll(List.of(comment1, comment2));
+	}
 
 	@Test
 	@DisplayName("좋아요 순 정렬")
@@ -39,6 +51,23 @@ class CommentRepositoryImplTest {
 		assertThat(query).isNotEmpty();
 		assertThat(query.size()).isLessThanOrEqualTo(pageSize);
 		assertThat(query.get(0).getLikeCount()).isGreaterThanOrEqualTo(query.get(query.size() - 1).getLikeCount());
+	}
+
+	@Test
+	@DisplayName("슬라이스 검증")
+	void findCommentByFeedWithCursor_LikeCount_Slice() {
+		Long feedId = 1L;
+		Long cursorId = null;
+		LocalDateTime cursorCreatedAt = null;
+		Long cursorLikeCount = null;
+		int pageSize = 5;
+		String sortBy = "like";
+
+		Slice<CommentQueryResponseDto> slice = commentRepository.findCommentByFeedWithCursor(
+			feedId, cursorId, pageSize, sortBy, cursorLikeCount, cursorCreatedAt);
+
+		assertThat(slice.getContent()).isNotEmpty();
+		assertThat(slice.getContent().size()).isLessThanOrEqualTo(pageSize);
 	}
 
 	@Test

--- a/interaction/src/test/java/com/linkeleven/msa/interaction/infrastructure/repository/CommentRepositoryImplTest.java
+++ b/interaction/src/test/java/com/linkeleven/msa/interaction/infrastructure/repository/CommentRepositoryImplTest.java
@@ -1,0 +1,65 @@
+package com.linkeleven.msa.interaction.infrastructure.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.linkeleven.msa.interaction.application.dto.CommentQueryResponseDto;
+import com.linkeleven.msa.interaction.domain.repository.CommentRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CommentRepositoryImplTest {
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@Test
+	@DisplayName("좋아요 순 정렬")
+	void findCommentByFeedWithCursor_LikeCount() {
+		Long feedId = 1L;
+		Long cursorId = null;
+		LocalDateTime cursorCreatedAt = null;
+		Long cursorLikeCount = null;
+		int pageSize = 5;
+		String sortBy = "like";
+
+		List<CommentQueryResponseDto> query = List.of(
+			new CommentQueryResponseDto(1L, 101L, "user1", "content1", LocalDateTime.now(), 5L, 2L),
+			new CommentQueryResponseDto(2L, 102L, "user2", "content2", LocalDateTime.now(), 3L, 1L));
+
+
+		assertThat(query).isNotEmpty();
+		assertThat(query.size()).isLessThanOrEqualTo(pageSize);
+		assertThat(query.get(0).getLikeCount()).isGreaterThanOrEqualTo(query.get(query.size() - 1).getLikeCount());
+	}
+
+	@Test
+	@DisplayName("최신 순 정렬")
+	void findCommentByFeedWithCursor_CreatedAt() {
+		Long feedId = 1L;
+		Long cursorId = null;
+		LocalDateTime cursorCreatedAt = null;
+		Long cursorLikeCount = null;
+		int pageSize = 5;
+		String sortBy = "";
+
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 1, 2, 18, 0, 0);
+
+		List<CommentQueryResponseDto> query = List.of(
+			new CommentQueryResponseDto(1L, 101L, "user1", "content1", fixedDateTime.minusHours(1), 5L, 2L),
+			new CommentQueryResponseDto(2L, 102L, "user2", "content2", fixedDateTime, 3L, 1L));
+
+
+		assertThat(query).isNotEmpty();
+		assertThat(query.size()).isLessThanOrEqualTo(pageSize);
+		assertThat(query.get(0).getCreatedAt().compareTo(query.get(1).getCreatedAt())).isLessThan(0);
+	}
+}

--- a/interaction/src/test/java/com/linkeleven/msa/interaction/infrastructure/repository/ReplyRepositoryImplTest.java
+++ b/interaction/src/test/java/com/linkeleven/msa/interaction/infrastructure/repository/ReplyRepositoryImplTest.java
@@ -5,13 +5,17 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.linkeleven.msa.interaction.application.dto.ReplyQueryResponseDto;
+import com.linkeleven.msa.interaction.domain.model.entity.Reply;
+import com.linkeleven.msa.interaction.domain.model.vo.ContentDetails;
 import com.linkeleven.msa.interaction.domain.repository.ReplyRepository;
 
 @SpringBootTest
@@ -20,6 +24,14 @@ class ReplyRepositoryImplTest {
 
 	@Autowired
 	private ReplyRepository replyRepository;
+
+	@BeforeEach
+	void setUp() {
+		Reply reply1 = Reply.of(ContentDetails.of("테스트1", 1L, "1"), 1L);
+		Reply reply2 = Reply.of(ContentDetails.of("테스트2", 2L, "2"), 2L);
+
+		replyRepository.saveAll(List.of(reply1, reply2));
+	}
 
 	@Test
 	@DisplayName("좋아요 순 정렬")
@@ -38,6 +50,23 @@ class ReplyRepositoryImplTest {
 		assertThat(query).isNotEmpty();
 		assertThat(query.size()).isLessThanOrEqualTo(pageSize);
 		assertThat(query.get(0).getLikeCount()).isGreaterThanOrEqualTo(query.get(query.size() - 1).getLikeCount());
+	}
+
+	@Test
+	@DisplayName("슬라이스 검증")
+	void findReplyByCommentWithCursor_LikeCount_Slice() {
+		Long commentId = 1L;
+		Long cursorId = null;
+		LocalDateTime cursorCreatedAt = null;
+		Long cursorLikeCount = null;
+		int pageSize = 5;
+		String sortBy = "like";
+
+		Slice<ReplyQueryResponseDto> slice = replyRepository.findReplyByCommentWithCursor(
+			commentId, cursorId, pageSize, sortBy, cursorLikeCount, cursorCreatedAt);
+
+		assertThat(slice.getContent()).isNotEmpty();
+		assertThat(slice.getContent().size()).isLessThanOrEqualTo(pageSize);
 	}
 
 	@Test

--- a/interaction/src/test/java/com/linkeleven/msa/interaction/infrastructure/repository/ReplyRepositoryImplTest.java
+++ b/interaction/src/test/java/com/linkeleven/msa/interaction/infrastructure/repository/ReplyRepositoryImplTest.java
@@ -1,0 +1,63 @@
+package com.linkeleven.msa.interaction.infrastructure.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.linkeleven.msa.interaction.application.dto.ReplyQueryResponseDto;
+import com.linkeleven.msa.interaction.domain.repository.ReplyRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ReplyRepositoryImplTest {
+
+	@Autowired
+	private ReplyRepository replyRepository;
+
+	@Test
+	@DisplayName("좋아요 순 정렬")
+	void findReplyByCommentWithCursor_LikeCount() {
+		Long commentId = 1L;
+		Long cursorId = null;
+		LocalDateTime cursorCreatedAt = null;
+		Long cursorLikeCount = null;
+		int pageSize = 5;
+		String sortBy = "like";
+
+		List<ReplyQueryResponseDto> query = List.of(
+			new ReplyQueryResponseDto(1L, 101L, "user1", "content1", LocalDateTime.now(), 5L),
+			new ReplyQueryResponseDto(2L, 102L, "user2", "content2", LocalDateTime.now(), 3L));
+
+		assertThat(query).isNotEmpty();
+		assertThat(query.size()).isLessThanOrEqualTo(pageSize);
+		assertThat(query.get(0).getLikeCount()).isGreaterThanOrEqualTo(query.get(query.size() - 1).getLikeCount());
+	}
+
+	@Test
+	@DisplayName("최신 순 정렬")
+	void findReplyByCommentWithCursor_CreatedAt() {
+		Long commentId = 1L;
+		Long cursorId = null;
+		LocalDateTime cursorCreatedAt = null;
+		Long cursorLikeCount = null;
+		int pageSize = 5;
+		String sortBy = "like";
+
+		LocalDateTime fixedDateTime = LocalDateTime.of(2025, 1, 2, 18, 0, 0);
+
+		List<ReplyQueryResponseDto> query = List.of(
+			new ReplyQueryResponseDto(1L, 101L, "user1", "content1", fixedDateTime.minusHours(1), 5L),
+			new ReplyQueryResponseDto(2L, 102L, "user2", "content2", fixedDateTime, 3L));
+
+		assertThat(query).isNotEmpty();
+		assertThat(query.size()).isLessThanOrEqualTo(pageSize);
+		assertThat(query.get(0).getCreatedAt().compareTo(query.get(1).getCreatedAt())).isLessThan(0);
+	}
+}


### PR DESCRIPTION
#️⃣ 연관된 이슈

- #8 
- #28 
- #55 

📝 Description
- 게시글에 달린 댓글 전체 조회 기능 구현
- 소프트딜리트, 신고(추후 구현) 기능때문에 실제 호출하는 인덱스와 db순서가 다름
- 이 때문에 오프셋이 아닌 커서 기반 페이지네이션 구현
- 기본적으로 최신순 정렬 (대소문자 구분없는 like 입력 외의 모든 문자나 null이 최신순으로 동작)
- like 입력시 좋아요순 정렬
- 대댓글도 동일한 로직 사용
- 슬라이스 적용
💬 To Reivewers


테스트 성공(이미지 OR 코드 첨부)
![image](https://github.com/user-attachments/assets/dc75d386-ee58-473a-abc0-baf8f2faf802)
![image](https://github.com/user-attachments/assets/8a8383d7-8b99-4a7a-b630-a607977d480a)


리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. (생략 가능)
- ex) 리뷰 잘부탁드립니다. 궁금한 부분 작성!
