### PR TITLE
User FeignController설정 및 Kafka설정

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -28,6 +28,9 @@ ext {
 }
 
 dependencies {
+	//kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+
 	// H2 Database 의존성 추가
 	testImplementation 'com.h2database:h2'
 

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/dto/KafkaUpdateUsernameDto.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/dto/KafkaUpdateUsernameDto.java
@@ -1,0 +1,22 @@
+package com.linkeleven.msa.auth.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KafkaUpdateUsernameDto {
+	private Long userId;
+	private String username;
+
+	public static KafkaUpdateUsernameDto of(Long userId, String username) {
+		return KafkaUpdateUsernameDto.builder()
+			.userId(userId)
+			.username(username)
+			.build();
+	}
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/dto/UserInfoResponseDto.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/dto/UserInfoResponseDto.java
@@ -1,0 +1,19 @@
+package com.linkeleven.msa.auth.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInfoResponseDto {
+	private String username;
+	public static UserInfoResponseDto from(String username) {
+		return UserInfoResponseDto.builder()
+			.username(username)
+			.build();
+	}
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/service/CommentProduceService.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/service/CommentProduceService.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class KafkaService {
+public class CommentProduceService {
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 
 	public void sendMessage(String topic,KafkaUpdateUsernameDto kafkaDto) {

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/service/KafkaService.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/service/KafkaService.java
@@ -1,0 +1,18 @@
+package com.linkeleven.msa.auth.application.service;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import com.linkeleven.msa.auth.application.dto.KafkaUpdateUsernameDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaService {
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+
+	public void sendMessage(String topic,KafkaUpdateUsernameDto kafkaDto) {
+		kafkaTemplate.send(topic, kafkaDto);
+	}
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserQueryService.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserQueryService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.linkeleven.msa.auth.application.dto.UserQueryResponseDto;
-import com.linkeleven.msa.auth.domain.repository.UserRepositoryCustom;
+import com.linkeleven.msa.auth.domain.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserQueryService {
-	private final UserRepositoryCustom userRepository;
+	private final UserRepository userRepository;
 
 	public Slice<UserQueryResponseDto> getUsersByUsername(String username, Pageable pageable) {
 		return userRepository.findUserByUsername(username, pageable);

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserService.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserService.java
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserService {
 	private final UserRepository userRepository;
-	private final KafkaService kafkaService;
+	private final CommentProduceService commentProduceService;
 
 	public UserRoleResponseDto getUserRole(Long userId) {
 		User user=validateUserById(userId);
@@ -159,7 +159,7 @@ public class UserService {
 			new TransactionSynchronizationAdapter() {
 				@Override
 				public void afterCommit() {
-					kafkaService.sendMessage("username-change", dto);
+					commentProduceService.sendMessage("username-change", dto);
 				}
 			}
 		);

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserService.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserService.java
@@ -1,7 +1,11 @@
 package com.linkeleven.msa.auth.application.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import com.linkeleven.msa.auth.application.dto.KafkaUpdateUsernameDto;
+import com.linkeleven.msa.auth.application.dto.UserInfoResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserMyInfoResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserRoleResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserUpdateAnonymousResponseDto;
@@ -23,12 +27,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserService {
 	private final UserRepository userRepository;
+	private final KafkaService kafkaService;
 
 	public UserRoleResponseDto getUserRole(Long userId) {
 		User user=validateUserById(userId);
 		return UserRoleResponseDto.from(user.getRole().toString());
 	}
-
+	public UserInfoResponseDto getUsername(Long userId) {
+		User user=validateUserById(userId);
+		return UserInfoResponseDto.from(user.getUsername());
+	}
 	public UserMyInfoResponseDto getUserMyInfo(String userId) {
 		User user=validateUserById(Long.parseLong(userId));
 		return UserMyInfoResponseDto.from(user);
@@ -81,8 +89,10 @@ public class UserService {
 		User user=validateSameUser(Long.valueOf(headerId),userId,role);
 
 		user.updateUsername(userUpdateUsernameRequestDto.getUsername());
-		return UserUpdateUsernameResponseDto.of(user.getUserId(),user.getUsername());
 
+		kafkaAfterCommit("username-change",KafkaUpdateUsernameDto.of(user.getUserId(), user.getUsername()));
+
+		return UserUpdateUsernameResponseDto.of(user.getUserId(),user.getUsername());
 	}
 
 	@Transactional
@@ -143,4 +153,16 @@ public class UserService {
 			}else return false;
 		}
 	}
+
+	private void kafkaAfterCommit(String topic, KafkaUpdateUsernameDto dto) {
+		TransactionSynchronizationManager.registerSynchronization(
+			new TransactionSynchronizationAdapter() {
+				@Override
+				public void afterCommit() {
+					kafkaService.sendMessage("username-change", dto);
+				}
+			}
+		);
+	}
+
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/domain/repository/UserRepository.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/domain/repository/UserRepository.java
@@ -2,6 +2,10 @@ package com.linkeleven.msa.auth.domain.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import com.linkeleven.msa.auth.application.dto.UserQueryResponseDto;
 import com.linkeleven.msa.auth.domain.model.User;
 
 public interface UserRepository {
@@ -12,4 +16,6 @@ public interface UserRepository {
 	boolean existsByUsername(String username);
 
 	User save(User user);
+
+	Slice<UserQueryResponseDto> findUserByUsername(String username, Pageable pageable);
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/config/KafkaConfig.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,38 @@
+package com.linkeleven.msa.auth.infrastructure.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+	@Bean
+	public ProducerFactory<String, Object> producerFactory() {
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+		configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+		return new DefaultKafkaProducerFactory<>(configProps);
+	}
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserQueryRepository.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserQueryRepository.java
@@ -1,10 +1,10 @@
-package com.linkeleven.msa.auth.domain.repository;
+package com.linkeleven.msa.auth.infrastructure.repository;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.linkeleven.msa.auth.application.dto.UserQueryResponseDto;
 
-public interface UserRepositoryCustom {
+public interface UserQueryRepository {
 	Slice<UserQueryResponseDto> findUserByUsername(String username, Pageable pageable);
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserQueryRepositoryImpl.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserQueryRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.linkeleven.msa.auth.infrastructure.repository;
+
+import static com.linkeleven.msa.auth.domain.model.QUser.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import com.linkeleven.msa.auth.application.dto.UserQueryResponseDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepositoryImpl implements UserQueryRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Slice<UserQueryResponseDto> findUserByUsername(String username, Pageable pageable) {
+		List<UserQueryResponseDto> users = queryFactory
+			.select(Projections.constructor(UserQueryResponseDto.class,
+				user.userId,
+				user.username,
+				user.role.stringValue(),
+				user.isAnonymous,
+				user.isCouponIssued
+			))
+			.from(user)
+			.where(
+				username == null || username.isBlank()
+					? user.deletedBy.isNull() // 삭제되지 않은 사용자만 조회
+					: user.username.containsIgnoreCase(username)
+					.and(user.deletedBy.isNull())
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		boolean hasNext = users.size() > pageable.getPageSize();
+		if (hasNext) {
+			users.remove(users.size() - 1);
+		}
+
+		return new SliceImpl<>(users, pageable, hasNext);
+	}
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserRepositoryImpl.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserRepositoryImpl.java
@@ -1,29 +1,22 @@
 package com.linkeleven.msa.auth.infrastructure.repository;
 
-import static com.linkeleven.msa.auth.domain.model.QUser.*;
-
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import com.linkeleven.msa.auth.application.dto.UserQueryResponseDto;
 import com.linkeleven.msa.auth.domain.model.User;
 import com.linkeleven.msa.auth.domain.repository.UserRepository;
-import com.linkeleven.msa.auth.domain.repository.UserRepositoryCustom;
-import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class UserRepositoryImpl implements UserRepository , UserRepositoryCustom {
+public class UserRepositoryImpl implements UserRepository {
 	private final UserJpaRepository userJpaRepository;
-	private final JPAQueryFactory queryFactory;
+	private final UserQueryRepository userQueryRepository;
 
 	@Override
 	public Optional<User> findById(Long userId) {
@@ -43,31 +36,8 @@ public class UserRepositoryImpl implements UserRepository , UserRepositoryCustom
 	}
 
 	@Override
-	public Slice<UserQueryResponseDto> findUserByUsername(String username, Pageable pageable) {
-		List<UserQueryResponseDto> users = queryFactory
-			.select(Projections.constructor(UserQueryResponseDto.class,
-				user.userId,
-				user.username,
-				user.role.stringValue(),
-				user.isAnonymous,
-				user.isCouponIssued
-			))
-			.from(user)
-			.where(
-				username == null || username.isBlank()
-					? user.deletedBy.isNull() // 삭제되지 않은 사용자만 조회
-					: user.username.containsIgnoreCase(username)
-					.and(user.deletedBy.isNull())
-			)
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize() + 1)
-			.fetch();
-
-		boolean hasNext = users.size() > pageable.getPageSize();
-		if (hasNext) {
-			users.remove(users.size() - 1);
-		}
-
-		return new SliceImpl<>(users, pageable, hasNext);
+	public Slice<UserQueryResponseDto> findUserByUsername(String username, Pageable pageable){
+		return userQueryRepository.findUserByUsername(username, pageable);
 	}
+
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/external/UserExternalController.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/external/UserExternalController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.linkeleven.msa.auth.application.dto.UserInfoResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserRoleResponseDto;
 import com.linkeleven.msa.auth.application.service.UserService;
 
@@ -19,5 +20,10 @@ public class UserExternalController {
 	@GetMapping("/{userId}/role")
 	UserRoleResponseDto getUserRole(@PathVariable Long userId) {
 		return userService.getUserRole(userId);
+	}
+
+	@GetMapping("/{userId}")
+	UserInfoResponseDto getUsername(@PathVariable Long userId){
+		return userService.getUsername(userId);
 	}
 }

--- a/auth/src/main/resources/application-dev.yml
+++ b/auth/src/main/resources/application-dev.yml
@@ -18,6 +18,11 @@ spring:
         format_sql: true
     open-in-view: false
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 eureka:
   client:
     service-url:


### PR DESCRIPTION
#️⃣ 연관된 이슈

- #44 


📝 Description
- username 변경시 -> Kafka 메세지 발행 
- afterCommit으로 구현 하여 username 변경 실패시 kafka 메세지 발행 안됨
-  userId 로 username 반환하는 feigncontroller구성
-  UserRepositoryCustom -> UserQueryRepository 로 변경
💬 To Reivewers


테스트 성공(이미지 OR 코드 첨부)
- username 변경시 kafka Ui Message 증가
- 변경 실패시 증가 안하는 것 확인
<img width="1255" alt="스크린샷 2025-01-08 오전 11 04 34" src="https://github.com/user-attachments/assets/9701c278-5fd2-44ae-852a-192cf78a4159" />


리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. (생략 가능)
- ex) 리뷰 잘부탁드립니다. 궁금한 부분 작성!
