### PR TITLE
팔로우 조회 검색 삭제 구현 및 유저 feignn client구현

### DIFF
--- a/auth/src/main/java/com/linkeleven/msa/auth/application/dto/FollowingQueryResponseDto.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/dto/FollowingQueryResponseDto.java
@@ -1,0 +1,20 @@
+package com.linkeleven.msa.auth.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowingQueryResponseDto {
+	private String username;
+
+	public static FollowingQueryResponseDto from(String username){
+		return FollowingQueryResponseDto.builder()
+			.username(username)
+			.build();
+	}
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/dto/UserIdAndRoleResponseDto.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/dto/UserIdAndRoleResponseDto.java
@@ -1,0 +1,22 @@
+package com.linkeleven.msa.auth.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserIdAndRoleResponseDto {
+	private Long userId;
+	private String role;
+
+	public static UserIdAndRoleResponseDto of(Long userId, String role) {
+		return UserIdAndRoleResponseDto.builder()
+			.userId(userId)
+			.role(role)
+			.build();
+	}
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/dto/UserValidateIdResponseDto.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/dto/UserValidateIdResponseDto.java
@@ -1,0 +1,20 @@
+package com.linkeleven.msa.auth.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserValidateIdResponseDto {
+	private Long userId;
+
+	public static UserValidateIdResponseDto from (Long userId) {
+		return UserValidateIdResponseDto.builder()
+			.userId(userId)
+			.build();
+	}
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/service/FollowQueryService.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/service/FollowQueryService.java
@@ -1,0 +1,42 @@
+package com.linkeleven.msa.auth.application.service;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import com.linkeleven.msa.auth.application.dto.FollowingQueryResponseDto;
+import com.linkeleven.msa.auth.domain.model.User;
+import com.linkeleven.msa.auth.domain.repository.FollowRepository;
+import com.linkeleven.msa.auth.domain.repository.UserRepository;
+import com.linkeleven.msa.auth.libs.exception.CustomException;
+import com.linkeleven.msa.auth.libs.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FollowQueryService {
+	private final UserRepository userRepository;
+	private final FollowRepository followRepository;
+
+	public Slice<FollowingQueryResponseDto> getFollowingList(String userId, String username, Pageable pageable) {
+		User user = validateUserById(Long.valueOf(userId));
+		return followRepository.findMyFollowByUsername(user, username, pageable,true); //true-> user의 following목록 조회
+	}
+
+	public Slice<FollowingQueryResponseDto> getFollowerList(String userId, String username, Pageable pageable) {
+		User user = validateUserById(Long.valueOf(userId));
+		return followRepository.findMyFollowByUsername(user, username, pageable,false);//false-> user의 follower목록 조회
+	}
+
+	private User validateUserById(Long userId) {
+		User user = userRepository.findById(userId).orElseThrow(
+			() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+		if (user.getDeletedBy() != null) {
+			throw new CustomException(ErrorCode.USER_NOT_FOUND);
+		}
+		return user;
+	}
+
+
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/service/FollowService.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/service/FollowService.java
@@ -40,6 +40,17 @@ public class FollowService {
 		followRepository.save(Follow.createFollow(user, followingUser));
 		return FollowingUsernameResponseDto.from(followingUser.getUsername());
 	}
+	@Transactional
+	public void deleteFollowing(Long userId, Long followingId) {
+		Follow follow = deletefollow(userId, followingId);
+		follow.deleteUser(userId);
+	}
+
+	@Transactional
+	public void deleteFollower(Long followerId, Long userId) {
+		Follow follow = deletefollow(followerId, userId);
+		follow.deleteUser(userId);
+	}
 
 	private boolean validateFollowing(User user, User following) {
 		return followRepository.existsByFollowerAndFollowing(user, following);
@@ -65,4 +76,19 @@ public class FollowService {
 		}
 	}
 
+	private Follow deletefollow(Long followerId, Long followingId) {
+		validateFollowingSelf(followerId,followingId);
+
+		User follwer = validateUserById(followerId);
+		User following = validateUserById(followingId);
+
+		if (!validateFollowing(follwer, following)) {
+			new CustomException(ErrorCode.NOT_FOLLOWING_USER);
+		}
+		Follow follow = validateFollowByUser(follwer, following);
+		if (follow.getDeletedAt() != null) {
+			new CustomException(ErrorCode.ALREADY_UNFOLLOWING);
+		}
+		return follow;
+	}
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserService.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserService.java
@@ -2,6 +2,9 @@ package com.linkeleven.msa.auth.application.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
@@ -45,9 +48,18 @@ public class UserService {
 	public List<UserIdAndRoleResponseDto> getUserRoleList(List<Long> userIdList) {
 		List<UserIdAndRoleResponseDto> responseDtoList =new ArrayList<>();
 
+		List<User> userList = userRepository.findAllUserInId(userIdList);
+		// userIdList ->인기 게시글 1, 2, 3 등 작성자
+		// -> where in을 사용 매치 안되면 안나올텐데
+		// 그러면 중간에 탈퇴한 사람 있으면 우짬? -> 빼고 보내주자
+		Map<Long, User> userMap = userList.stream()
+			.collect(Collectors.toMap(User::getUserId, Function.identity()));
+
 		for (Long userId : userIdList) {
-			User user=validateUserById(userId);
-			responseDtoList.add(UserIdAndRoleResponseDto.of(user.getUserId(),user.getRole().toString()));
+			if(userMap.containsKey(userId)){
+				User user=userMap.get(userId);
+				responseDtoList.add(UserIdAndRoleResponseDto.of(user.getUserId(),user.getRole().toString()));
+			}
 		}
 		return responseDtoList;
 	}

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserService.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserService.java
@@ -15,6 +15,7 @@ import com.linkeleven.msa.auth.application.dto.UserRoleResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserUpdateAnonymousResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserUpdateCouponIssuedResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserUpdateUsernameResponseDto;
+import com.linkeleven.msa.auth.application.dto.UserValidateIdResponseDto;
 import com.linkeleven.msa.auth.domain.common.UserRole;
 import com.linkeleven.msa.auth.domain.model.User;
 import com.linkeleven.msa.auth.domain.repository.UserRepository;
@@ -49,6 +50,11 @@ public class UserService {
 			responseDtoList.add(UserIdAndRoleResponseDto.of(user.getUserId(),user.getRole().toString()));
 		}
 		return responseDtoList;
+	}
+
+	public UserValidateIdResponseDto getValidateUserId(Long userId) {
+		User user=validateUserById(userId);
+		return UserValidateIdResponseDto.from(user.getUserId());
 	}
 
 	public UserMyInfoResponseDto getUserMyInfo(String userId) {

--- a/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserService.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/application/service/UserService.java
@@ -1,10 +1,14 @@
 package com.linkeleven.msa.auth.application.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.linkeleven.msa.auth.application.dto.KafkaUpdateUsernameDto;
+import com.linkeleven.msa.auth.application.dto.UserIdAndRoleResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserInfoResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserMyInfoResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserRoleResponseDto;
@@ -37,6 +41,16 @@ public class UserService {
 		User user=validateUserById(userId);
 		return UserInfoResponseDto.from(user.getUsername());
 	}
+	public List<UserIdAndRoleResponseDto> getUserRoleList(List<Long> userIdList) {
+		List<UserIdAndRoleResponseDto> responseDtoList =new ArrayList<>();
+
+		for (Long userId : userIdList) {
+			User user=validateUserById(userId);
+			responseDtoList.add(UserIdAndRoleResponseDto.of(user.getUserId(),user.getRole().toString()));
+		}
+		return responseDtoList;
+	}
+
 	public UserMyInfoResponseDto getUserMyInfo(String userId) {
 		User user=validateUserById(Long.parseLong(userId));
 		return UserMyInfoResponseDto.from(user);
@@ -164,5 +178,6 @@ public class UserService {
 			}
 		);
 	}
+
 
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/domain/repository/FollowRepository.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/domain/repository/FollowRepository.java
@@ -2,6 +2,10 @@ package com.linkeleven.msa.auth.domain.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import com.linkeleven.msa.auth.application.dto.FollowingQueryResponseDto;
 import com.linkeleven.msa.auth.domain.model.Follow;
 import com.linkeleven.msa.auth.domain.model.User;
 
@@ -14,4 +18,5 @@ public interface FollowRepository {
 
 	Optional<Follow> findByFollowerAndFollowing(User follower,User following);
 
+	Slice<FollowingQueryResponseDto> findMyFollowByUsername(User user,String username, Pageable pageable,boolean isFollowing);
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/domain/repository/UserRepository.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/domain/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.linkeleven.msa.auth.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,7 @@ import com.linkeleven.msa.auth.domain.model.User;
 public interface UserRepository {
 
 	Optional<User> findById(Long userId);
+
 	Optional<User> findByUsername(String username);
 
 	boolean existsByUsername(String username);
@@ -18,4 +20,6 @@ public interface UserRepository {
 	User save(User user);
 
 	Slice<UserQueryResponseDto> findUserByUsername(String username, Pageable pageable);
+
+	List<User> findAllUserInId(List<Long> userIdList);
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/FollowQueryRepository.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/FollowQueryRepository.java
@@ -1,0 +1,11 @@
+package com.linkeleven.msa.auth.infrastructure.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import com.linkeleven.msa.auth.application.dto.FollowingQueryResponseDto;
+import com.linkeleven.msa.auth.domain.model.User;
+
+public interface FollowQueryRepository {
+	Slice<FollowingQueryResponseDto> findMyFollowByUsername(User user,String username, Pageable pageable,boolean isFollowing);
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/FollowQueryRepositoryImpl.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/FollowQueryRepositoryImpl.java
@@ -1,0 +1,67 @@
+package com.linkeleven.msa.auth.infrastructure.repository;
+
+import static com.linkeleven.msa.auth.domain.model.QFollow.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import com.linkeleven.msa.auth.application.dto.FollowingQueryResponseDto;
+
+import com.linkeleven.msa.auth.domain.model.User;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class FollowQueryRepositoryImpl implements FollowQueryRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Slice<FollowingQueryResponseDto> findMyFollowByUsername(
+		User user,
+		String username,
+		Pageable pageable,
+		boolean isFollowing
+	) {
+		List<FollowingQueryResponseDto> followings = queryFactory
+			.select(Projections.constructor(FollowingQueryResponseDto.class,
+				isFollowing?follow.following.username:follow.follower.username
+			))
+			.from(follow)
+			.where(searchFollowingCondition(user, username, isFollowing))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize() + 1)
+			.fetch();
+
+		boolean hasNext = followings.size() > pageable.getPageSize();
+		if (hasNext) {
+			followings.remove(followings.size() - 1);
+		}
+
+		return new SliceImpl<>(followings, pageable, hasNext);
+	}
+
+	private BooleanExpression searchFollowingCondition(User user, String username, boolean isFollowing) {
+		BooleanExpression isNotDeleted = follow.deletedBy.isNull();
+		//isFollowing -> true :user = follower (유저의 팔로잉 목록)
+		//isFollowing -> false :user = following (유저의 팔로워 목록)
+		BooleanExpression isMyFollow = isFollowing ? follow.follower.eq(user) : follow.following.eq(user);
+
+		if (username == null || username.isBlank()) {
+			return isMyFollow.and(isNotDeleted);
+		}
+
+		BooleanExpression isResult = isFollowing
+			? follow.following.username.containsIgnoreCase(username)
+			: follow.follower.username.containsIgnoreCase(username);
+
+		return isResult.and(isMyFollow).and(isNotDeleted);
+	}
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/FollowRepositoryImpl.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/FollowRepositoryImpl.java
@@ -2,8 +2,11 @@ package com.linkeleven.msa.auth.infrastructure.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
+import com.linkeleven.msa.auth.application.dto.FollowingQueryResponseDto;
 import com.linkeleven.msa.auth.domain.model.Follow;
 import com.linkeleven.msa.auth.domain.model.User;
 import com.linkeleven.msa.auth.domain.repository.FollowRepository;
@@ -14,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FollowRepositoryImpl implements FollowRepository {
 	private final FollowJpaRepository followJpaRepository;
+	private final FollowQueryRepository followQueryRepository;
 
 	@Override
 	public Follow save(Follow follow){
@@ -32,6 +36,11 @@ public class FollowRepositoryImpl implements FollowRepository {
 	@Override
 	public Optional<Follow> findByFollowerAndFollowing(User follower,User following){
 		return followJpaRepository.findByFollowerAndFollowing(follower, following);
+	}
+
+	@Override
+	public Slice<FollowingQueryResponseDto> findMyFollowByUsername(User user,String username, Pageable pageable,boolean isFollowing){
+		return followQueryRepository.findMyFollowByUsername(user,username,pageable,isFollowing);
 	}
 }
 

--- a/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserQueryRepository.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserQueryRepository.java
@@ -1,10 +1,14 @@
 package com.linkeleven.msa.auth.infrastructure.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 import com.linkeleven.msa.auth.application.dto.UserQueryResponseDto;
+import com.linkeleven.msa.auth.domain.model.User;
 
 public interface UserQueryRepository {
 	Slice<UserQueryResponseDto> findUserByUsername(String username, Pageable pageable);
+	List<User> findAllUserInId(List<Long> userIdList);
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserQueryRepositoryImpl.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserQueryRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import com.linkeleven.msa.auth.application.dto.UserQueryResponseDto;
+import com.linkeleven.msa.auth.domain.model.User;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -44,6 +45,7 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
 
 		return new SliceImpl<>(users, pageable, hasNext);
 	}
+
 	private BooleanExpression searchCondition(String username) {
 
 		BooleanExpression isNotDeleted = user.deletedBy.isNull();
@@ -53,5 +55,17 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
 		}
 
 		return user.username.containsIgnoreCase(username).and(isNotDeleted);
+	}
+
+	@Override
+	public List<User> findAllUserInId(List<Long> userIdList) {
+		return queryFactory.query()
+			.select(user)
+			.from(user)
+			.where(
+				user.deletedBy.isNull(),
+				user.userId.in(userIdList)
+			)
+			.fetch();
 	}
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserRepositoryImpl.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/infrastructure/repository/UserRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.linkeleven.msa.auth.infrastructure.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
@@ -38,6 +39,11 @@ public class UserRepositoryImpl implements UserRepository {
 	@Override
 	public Slice<UserQueryResponseDto> findUserByUsername(String username, Pageable pageable){
 		return userQueryRepository.findUserByUsername(username, pageable);
+	}
+
+	@Override
+	public List<User> findAllUserInId(List<Long> userIdList){
+		return userQueryRepository.findAllUserInId(userIdList);
 	}
 
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/libs/exception/ErrorCode.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/libs/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
 	/*  409 CONFLICT : Resource 중복  */
 	USERNAME_ALREADY_EXISTS(409, "이미 존재하는 사용자 이름입니다."),
 	ALREADY_FOLLOWING(409,"이미 팔로잉한 유저입니다."),
+	ALREADY_UNFOLLOWING(409,"이미 팔로잉을 삭제한 유저입니다."),
 
 	/*  500 INTERNAL_SERVER_ERROR : 서버 에러  */
 	INTERNAL_SERVER_ERROR(500, "내부 서버 에러입니다.");

--- a/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/FollowController.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/FollowController.java
@@ -1,6 +1,8 @@
 package com.linkeleven.msa.auth.presentation.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -32,4 +34,25 @@ public class FollowController {
 			));
 	}
 
+	@DeleteMapping("/following/{followingId}")
+	public ResponseEntity<SuccessResponseDto<Void>> deleteFollowing(
+		@RequestHeader("X-User-Id") String userId,
+		@PathVariable Long followingId
+	) {
+		followService.deleteFollowing(Long.valueOf(userId), followingId);
+		return ResponseEntity.ok().body(
+			SuccessResponseDto.success("팔로잉이 삭제되었습니다.")
+		);
+	}
+
+	@DeleteMapping("/follower/{followerId}")
+	public ResponseEntity<SuccessResponseDto<Void>> deleteFollower(
+		@RequestHeader("X-User-Id") String userId,
+		@PathVariable Long followerId
+	) {
+		followService.deleteFollower(followerId, Long.valueOf(userId));
+		return ResponseEntity.ok().body(
+			SuccessResponseDto.success("팔로워가 삭제되었습니다.")
+		);
+	}
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/FollowQueryController.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/FollowQueryController.java
@@ -1,0 +1,47 @@
+package com.linkeleven.msa.auth.presentation.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.linkeleven.msa.auth.application.dto.FollowingQueryResponseDto;
+import com.linkeleven.msa.auth.application.service.FollowQueryService;
+import com.linkeleven.msa.auth.libs.dto.SuccessResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/follows")
+public class FollowQueryController {
+	private final FollowQueryService followQueryService;
+
+	@GetMapping("/following")
+	public ResponseEntity<SuccessResponseDto<Slice<FollowingQueryResponseDto>>> getFollowingList(
+		@RequestHeader("X-User-Id") String userId,
+		@RequestParam(required = false) String username,
+		Pageable pageable
+	) {
+		return ResponseEntity.ok().body(SuccessResponseDto.success(
+			"팔로잉 조회가 되었습니다.",
+			followQueryService.getFollowingList(userId, username, pageable)
+		));
+	}
+
+	@GetMapping("/follower")
+	public ResponseEntity<SuccessResponseDto<Slice<FollowingQueryResponseDto>>> getFollowerList(
+		@RequestHeader("X-User-Id") String userId,
+		@RequestParam(required = false) String username,
+		Pageable pageable
+	) {
+		return ResponseEntity.ok().body(SuccessResponseDto.success(
+			"팔로우 조회가 되었습니다.",
+			followQueryService.getFollowerList(userId, username, pageable)
+		));
+	}
+}

--- a/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/external/UserExternalController.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/external/UserExternalController.java
@@ -38,7 +38,7 @@ public class UserExternalController {
 		return userService.getUserRoleList(userIdList);
 	}
 
-	@GetMapping("/{userId}/validaete")
+	@GetMapping("/{userId}/validate")
 	UserValidateIdResponseDto getValidateUserId(@PathVariable Long userId){
 		return userService.getValidateUserId(userId);
 	}

--- a/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/external/UserExternalController.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/external/UserExternalController.java
@@ -1,10 +1,15 @@
 package com.linkeleven.msa.auth.presentation.controller.external;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.linkeleven.msa.auth.application.dto.UserIdAndRoleResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserInfoResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserRoleResponseDto;
 import com.linkeleven.msa.auth.application.service.UserService;
@@ -25,5 +30,10 @@ public class UserExternalController {
 	@GetMapping("/{userId}")
 	UserInfoResponseDto getUsername(@PathVariable Long userId){
 		return userService.getUsername(userId);
+	}
+
+	@PostMapping("/roles")
+	List<UserIdAndRoleResponseDto> getUserRoleList(@RequestBody List<Long> userIdList) {
+		return userService.getUserRoleList(userIdList);
 	}
 }

--- a/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/external/UserExternalController.java
+++ b/auth/src/main/java/com/linkeleven/msa/auth/presentation/controller/external/UserExternalController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.linkeleven.msa.auth.application.dto.UserIdAndRoleResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserInfoResponseDto;
 import com.linkeleven.msa.auth.application.dto.UserRoleResponseDto;
+import com.linkeleven.msa.auth.application.dto.UserValidateIdResponseDto;
 import com.linkeleven.msa.auth.application.service.UserService;
 
 import lombok.RequiredArgsConstructor;
@@ -35,5 +36,10 @@ public class UserExternalController {
 	@PostMapping("/roles")
 	List<UserIdAndRoleResponseDto> getUserRoleList(@RequestBody List<Long> userIdList) {
 		return userService.getUserRoleList(userIdList);
+	}
+
+	@GetMapping("/{userId}/validaete")
+	UserValidateIdResponseDto getValidateUserId(@PathVariable Long userId){
+		return userService.getValidateUserId(userId);
 	}
 }


### PR DESCRIPTION
#️⃣ 연관된 이슈

- #76 , #73, #74


📝 Description
- 팔로우 조회 검색 구현
- 팔로우 삭제 구현
- 요구하신 유저 feign client 구현하였습니다.
💬 To Reivewers


테스트 성공(이미지 OR 코드 첨부)
-  팔로우 검색 및 조회 성공
<img width="785" alt="스크린샷 2025-01-10 오후 12 51 33" src="https://github.com/user-attachments/assets/c92ab94d-b907-43a1-9cf6-8b15ad0cf8c2" />
-팔로우 삭제 구현
<img width="787" alt="스크린샷 2025-01-10 오후 12 51 25" src="https://github.com/user-attachments/assets/642c4ae6-8010-4900-b2db-0707b0244f25" />



리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. (생략 가능)
- ex) 리뷰 잘부탁드립니다. 궁금한 부분 작성!
